### PR TITLE
Refactor server response routes in order to pre-compile all templates.

### DIFF
--- a/join.js
+++ b/join.js
@@ -242,7 +242,7 @@ function routeRequest (proxyParameters, request, response) {
   const { port, proxy } = proxyParameters;
   switch (proxy) {
     case 'https':
-      routes.webProxy({ port, path }, request, response);
+      routes.webProxy(request, response, { port, path });
       return;
 
     case 'none':

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,11 +1,21 @@
 // Copyright © 2015 Jan Keromnes. All rights reserved.
 // The following code is covered by the AGPL-3.0 license.
 
-let http = require('http');
+const camp = require('@jankeromnes/camp');
+const http = require('http');
 
-let db = require('./db');
-let machines = require('./machines');
-let metrics = require('./metrics');
+const db = require('./db');
+const machines = require('./machines');
+const metrics = require('./metrics');
+
+// FIXME: Remove this workaround for https://github.com/espadrine/sc/issues/59.
+// We should use relative template file paths when this issue is fixed.
+const cwd = process.cwd();
+
+// Teach the templating system how to generate IDs (matching /[a-z0-9_-]*/).
+camp.templateReader.parsers.id = text => {
+  return text.replace(/[^\w-]/g, '').toLowerCase();
+};
 
 // Redirect to a target url.
 exports.redirect = function (response, url, permanently) {
@@ -14,253 +24,269 @@ exports.redirect = function (response, url, permanently) {
   response.end();
 };
 
-// Public landing page.
-exports.landingPage = function (user, end) {
-  let title = '';
-  let projects = db.get('projects');
+// Common web app templates.
+const appHeader = camp.template(cwd + '/templates/header.html');
+const appFooter = camp.template(cwd + '/templates/footer.html');
 
-  end({
+// Public landing page.
+const landingSection = camp.template([
+  cwd + '/templates/landing.html',
+  cwd + '/templates/projects.html'
+]);
+exports.landingPage = function (response, user = null) {
+  const title = '';
+  const projects = db.get('projects');
+
+  response.template({
     machines: user ? machines.getAvailableMachines(user) : null,
-    projects: projects,
-    title: title,
-    user: user,
+    projects,
+    title,
+    user,
     scripts: [
       '/js/landing.js',
       '/js/jquery.timeago.js',
       '/js/projects.js'
     ]
-  }, { template: [
-    '../templates/header.html',
-    '../templates/landing.html',
-    '../templates/projects.html',
-    '../templates/footer.html'
-  ]});
+  }, [
+    appHeader,
+    landingSection,
+    appFooter
+  ]);
 };
 
 // Public blog page.
-exports.blogPage = function (user, end) {
-  let title = 'Blog';
+const blogSection = camp.template(cwd + '/templates/blog.html');
+exports.blogPage = function (response, user = null) {
+  const title = 'Blog';
 
-  end({
-    title: title,
-    user: user,
+  response.template({
+    title,
+    user,
     scripts: []
-  }, { template: [
-    '../templates/header.html',
-    '../templates/blog.html',
-    '../templates/footer.html'
-  ]});
+  }, [
+    appHeader,
+    blogSection,
+    appFooter
+  ]);
 };
 
-// Public projects page.
-exports.projectsPage = function (user, end) {
-  let title = 'Projects';
-  let projects = db.get('projects');
+// Public projects list page.
+const projectsSection = camp.template([
+  cwd + '/templates/projects.html',
+  cwd + '/templates/projects-hint.html'
+]);
+exports.projectsPage = function (response, user = null) {
+  const title = 'Projects';
+  const projects = db.get('projects');
 
-  end({
+  response.template({
     machines: user ? machines.getAvailableMachines(user) : null,
-    projects: projects,
-    title: title,
-    user: user,
+    projects,
+    title,
+    user,
     scripts: [
       '/js/jquery.timeago.js',
       '/js/projects.js'
     ]
-  }, { template: [
-    '../templates/header.html',
-    '../templates/projects.html',
-    '../templates/projects-hint.html',
-    '../templates/footer.html'
-  ]});
+  }, [
+    appHeader,
+    projectsSection,
+    appFooter
+  ]);
 };
 
 // Public project-specific page.
-exports.projectPage = function (project, user, end) {
-  let title = project.name;
+const projectSection = camp.template(cwd + '/templates/project.html');
+exports.projectPage = function (response, project, user = null) {
+  const title = project.name;
 
-  end({
-    project: project,
-    title: title,
-    user: user,
+  response.template({
+    project,
+    title,
+    user,
     scripts: [
       '/js/dygraph-combined.js',
       '/js/jquery.timeago.js',
       '/js/projects.js',
       '/js/graphs.js'
     ]
-  }, { template: [
-    '../templates/header.html',
-    '../templates/project.html',
-    '../templates/footer.html'
-  ]});
+  }, [
+    appHeader,
+    projectSection,
+    appFooter
+  ]);
 };
 
 // User login page.
-exports.loginPage = function (end) {
-  let title = 'Sign In';
+const loginSection = camp.template(cwd + '/templates/login.html');
+exports.loginPage = function (response) {
+  const title = 'Sign In';
 
-  end({
-    title: title,
+  response.template({
+    title,
     user: null,
     scripts: [
       '/js/login.js'
     ]
-  }, { template: [
-    '../templates/header.html',
-    '../templates/login.html',
-    '../templates/footer.html'
-  ]});
+  }, [
+    appHeader,
+    loginSection,
+    appFooter
+  ]);
 };
 
 // User contributions list.
-exports.contributionsPage = function (user, end) {
-  let title = 'My Contributions';
-  let projects = db.get('projects');
+const contributionsTemplate = camp.template(cwd + '/templates/contributions.html');
+exports.contributionsPage = function (response, user = null) {
+  const title = 'My Contributions';
+  const projects = db.get('projects');
 
-  end({
-    projects: projects,
-    title: title,
-    user: user,
+  response.template({
+    projects,
+    title,
+    user,
     scripts: [
       '/js/jquery.timeago.js',
       '/js/projects.js'
     ]
-  }, { template: [
-    '../templates/header.html',
-    '../templates/contributions.html',
-    '../templates/footer.html'
-  ]});
+  }, [
+    appHeader,
+    contributionsTemplate,
+    appFooter
+  ]);
 };
 
 // User settings page.
-exports.settingsPage = function (section, user, end, query) {
-  let title = 'Settings';
-  let template = null;
-
-  switch (section) {
-    case 'account':
-      template = '../templates/settings-account.html';
-      break;
-
-    default:
-      // The requested section doesn't exist!
-      exports.notFoundPage(user, end, query);
-      return;
+const settingsSections = {
+  account: camp.template(cwd + '/templates/settings-account.html')
+};
+const settingsHint = camp.template(cwd + '/templates/settings-hint.html');
+exports.settingsPage = function (response, section, user = null) {
+  const title = 'Settings';
+  const template = settingsSections[section];
+  if (!template) {
+    // The requested section doesn't exist!
+    exports.notFoundPage(response, user);
+    return;
   }
 
-  end({
-    section: section,
-    title: title,
-    user: user,
+  response.template({
+    section,
+    title,
+    user,
     scripts: [
       '/js/settings.js'
     ]
-  }, { template: [
-    '../templates/header.html',
+  }, [
+    appHeader,
     template,
-    '../templates/settings-hint.html',
-    '../templates/footer.html'
-  ]});
+    settingsHint,
+    appFooter
+  ]);
 };
 
 // Live data page.
-exports.dataPage = function (user, end) {
-  let title = 'Data';
+const dataSection = camp.template(cwd + '/templates/data.html');
+exports.dataPage = function (response, user) {
+  const title = 'Data';
 
-  metrics.get(function (data) {
-    end({
-      data: data,
-      title: title,
-      user: user,
+  metrics.get(data => {
+    response.template({
+      data,
+      title,
+      user,
       scripts: []
-    }, { template: [
-      '../templates/header.html',
-      '../templates/data.html',
-      '../templates/footer.html'
-    ]});
+    }, [
+      appHeader,
+      dataSection,
+      appFooter
+    ]);
   });
 };
 
 // Admin page.
-exports.adminPage = function (section, user, end, query) {
-  let title = 'Admin';
+const adminHeader = camp.template(cwd + '/templates/admin-header.html');
+const adminSections = {
+  hosts: camp.template(cwd + '/templates/admin-hosts.html'),
+  projects: camp.template(cwd + '/templates/admin-projects.html'),
+  users: camp.template(cwd + '/templates/admin-users.html')
+};
+exports.adminPage = function (response, section, user) {
+  const title = 'Admin';
+  const template = adminSections[section];
+  if (!template) {
+    // The requested section doesn't exist!
+    exports.notFoundPage(response, user);
+    return;
+  }
+
   let hosts = null;
   let projects = null;
   let users = null;
   let waitlist = null;
-  let template = null;
-
   switch (section) {
     case 'hosts':
       hosts = db.get('hosts');
-      template = '../templates/admin-hosts.html';
       break;
 
     case 'projects':
       hosts = db.get('hosts');
       projects = db.get('projects');
-      template = '../templates/admin-projects.html';
       break;
 
     case 'users':
       users = db.get('users');
       waitlist = db.get('waitlist');
-      template = '../templates/admin-users.html';
       break;
-
-    default:
-      // The requested section doesn't exist!
-      exports.notFoundPage(user, end, query);
-      return;
   }
 
-  end({
-    hosts: hosts,
-    projects: projects,
-    users: users,
-    waitlist: waitlist,
-    section: section,
-    title: title,
-    user: user,
+  response.template({
+    hosts,
+    projects,
+    users,
+    waitlist,
+    section,
+    title,
+    user,
     scripts: [
       '/js/admin.js'
     ]
-  }, { template: [
-    '../templates/header.html',
-    '../templates/admin-header.html',
+  }, [
+    appHeader,
+    adminHeader,
     template,
-    '../templates/footer.html'
-  ]});
+    appFooter
+  ]);
 };
 
 // 404 Not Found page.
-exports.notFoundPage = function (user, end, query) {
-  let title = 'Page not found!';
+const notFoundSection = camp.template(cwd + '/templates/404.html');
+exports.notFoundPage = function (response, user) {
+  const title = 'Page not found!';
 
-  query.res.statusCode = 404;
-
-  end({
-    title: title,
-    user: user,
+  response.statusCode = 404;
+  response.template({
+    title,
+    user,
     scripts: []
-  }, { template: [
-    '../templates/header.html',
-    '../templates/404.html',
-    '../templates/footer.html'
-  ]});
+  }, [
+    appHeader,
+    notFoundSection,
+    appFooter
+  ]);
 };
 
 // Local web proxy.
-exports.webProxy = function (parameters, request, response) {
+exports.webProxy = function (request, response, parameters) {
   // Proxy request to the local port and path.
-  let options = {
+  const options = {
     hostname: 'localhost',
     port: parameters.port,
     path: parameters.path,
     method: request.method,
     headers: request.headers
   };
-  let proxy = http.request(options);
+  const proxy = http.request(options);
 
   proxy.on('response', res => {
     response.writeHead(res.statusCode, res.headers);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@jankeromnes/camp": "~16.2.13",
     "dockerode": "~2.4.1",
     "email-login": "~1.0.1",
-    "fast-json-patch": "~1.1.6",
+    "fast-json-patch": "~1.1.8",
     "le-acme-core": "~2.0.9",
     "node-forge": "~0.7.0",
     "oauth": "~0.9.15",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "node-forge": "~0.7.0",
     "oauth": "~0.9.15",
     "oauth2provider": "~0.0.2",
-    "selfapi": "~0.0.12",
+    "selfapi": "~0.0.15",
     "tar-stream": "~1.5.2"
   },
   "engines" : {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@jankeromnes/camp": "~16.2.13",
-    "dockerode": "~2.3.1",
+    "dockerode": "~2.4.1",
     "email-login": "~1.0.1",
     "fast-json-patch": "~1.1.6",
     "le-acme-core": "~2.0.9",


### PR DESCRIPTION
In theory, there should be no functional change here (except for the small `http.ServerResponse` bug-fix I sneaked in).

This pull request switches to [ScoutCamp](https://github.com/espadrine/sc)'s new preferred way to deal with templates, which allows pre-compiling templates with `camp.template()`, and serving templated responses by calling `response.template()` directly instead of relying on `camp.route()`'s `end()` callback (note: `camp.route()` is slowly being deprecated, as is `query`: eventually, every route should use `camp.path(pattern, (request, response) => {})`, but this will happen in future pull requests).

@bnjbvr, could you please verify that I didn't make any obvious mistakes?

@espadrine, could you please have a look at how I handle templates, and if this the fastest way to serve templates? (I'd like to have a look at template/scoutcamp performance in the near future.)