### PR TITLE
Allow forcing insecure HTTP for local development only

### DIFF
--- a/join.js
+++ b/join.js
@@ -2,6 +2,7 @@
 // The following code is covered by the AGPL-3.0 license.
 
 const camp = require('@jankeromnes/camp');
+const http = require('http');
 const nodepath = require('path');
 
 const boot = require('./lib/boot');
@@ -161,6 +162,15 @@ function ensureOAuth2Access (request, response, next) {
     // This session has an OAuth2 access token, so it's authenticated.
     // TODO: Also verify that the token is still valid, or renew it if not.
     next();
+    return;
+  }
+
+  // We can only use `http.ServerResponse`s to initiate OAuth2 authentication,
+  // not raw `net.Socket`s (as in WebSocket connections).
+  if (!(response instanceof http.ServerResponse)) {
+    const error = new Error('Unsupported response type (e.g. WebSocket)');
+    log('[fail] oauth2 redirect', error);
+    response.end();
     return;
   }
 

--- a/join.js
+++ b/join.js
@@ -34,18 +34,20 @@ boot.executeInParallel([
 
     const https = db.get('https');
     const ports = db.get('ports');
+    const security = db.get('security');
 
     // Start an authenticated Janitor proxy for Docker containers on this host.
     const proxy = camp.start({
       documentRoot: process.cwd() + '/static',
       port: ports.https,
-      secure: true,
+      secure: !security.forceHttp,
       key: https.key,
       cert: https.crt,
       ca: https.ca
     });
 
-    log('[ok] proxy → https://' + hostname + ':' + ports.https);
+    log('[ok] proxy → http' + (security.forceHttp ? '' : 's') + '://' +
+      hostname + ':' + ports.https);
 
     // Authenticate all requests with a series of server middlewares.
     proxy.handle(ensureSession);

--- a/lib/boot.js
+++ b/lib/boot.js
@@ -61,8 +61,14 @@ exports.forwardHttp = function (next) {
   });
 };
 
-// Verify HTTPS certificates, generate new ones if necessary.
+// Verify HTTPS certificates and generate new ones if necessary.
 exports.ensureHttpsCertificates = function (next) {
+  if (db.get('security').forceHttp) {
+    log('[warning] skipped https credentials verification');
+    next();
+    return;
+  }
+
   const https = db.get('https');
   const valid = certificates.isValid({
     ca: https.ca,

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -13,8 +13,8 @@ camp.templateReader.parsers.id = text => {
   return text.replace(/[^\w-]/g, '').toLowerCase();
 };
 
-// Redirect to a target url.
-exports.redirect = function (response, url, permanently) {
+// Redirect to a target URL.
+exports.redirect = function (response, url, permanently = false) {
   response.statusCode = permanently ? 301 : 302;
   response.setHeader('Location', url);
   response.end();

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -8,6 +8,8 @@ const db = require('./db');
 const machines = require('./machines');
 const metrics = require('./metrics');
 
+const security = db.get('security');
+
 // Teach the templating system how to generate IDs (matching /[a-z0-9_-]*/).
 camp.templateReader.parsers.id = text => {
   return text.replace(/[^\w-]/g, '').toLowerCase();
@@ -21,7 +23,11 @@ exports.redirect = function (response, url, permanently = false) {
 };
 
 // Common web app templates.
-const appHeader = camp.template('./templates/header.html');
+const appHeader = camp.template([
+  './templates/header.html'
+].concat(!security.forceInsecure ? [] : [
+  './templates/header-insecure.html'
+]));
 const appFooter = camp.template('./templates/footer.html');
 
 // Public landing page.

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -9,6 +9,7 @@ const login = new emaillogin({
   db: './tokens/',
   mailer: db.get('mailer')
 });
+const useSecureCookies = !db.get('security').forceInsecure;
 
 // Create a new session with a unique token.
 exports.create = function (callback) {
@@ -47,7 +48,7 @@ exports.get = function (request, callback) {
       if (request.cookies) {
         request.cookies.set('token', token, {
           expires: new Date('2038-01-19T03:14:07Z'),
-          secure: true
+          secure: useSecureCookies
         });
       }
 
@@ -63,7 +64,7 @@ exports.destroy = function (request, callback) {
       // Destroy the cookie.
       request.cookies.set('token', '', {
         overwrite: true,
-        secure: true
+        secure: useSecureCookies
       });
     }
 

--- a/lib/users.js
+++ b/lib/users.js
@@ -9,6 +9,8 @@ const metrics = require('./metrics');
 const sessions = require('./sessions');
 
 const hostname = db.get('hostname', 'localhost');
+const security = db.get('security');
+const baseUrl = (security.forceHttp ? 'http' : 'https') + '://' + hostname;
 
 // Get a user for the current session.
 exports.get = function (request, callback) {
@@ -110,17 +112,24 @@ exports.sendLoginEmail = function (email, request, callback) {
         return 'Janitor Sign-in link';
       },
       htmlMessage (key) {
+        const url = baseUrl + '/?key=' + encodeURIComponent(key);
+
+        if (security.forceInsecure) {
+          log('[warning] sign-in link for ' + email + ':', url);
+        }
+
         return '<p>Hello,</p>\n' +
         '<p>To sign in to the Janitor, please click ' +
-        '<a href="https://' + hostname + '/?key=' + key + '">here</a>.</p>\n' +
+          '<a href="' + url + '">here</a>.</p>\n' +
         '<p>This link will only work once, but you can get as many links as ' +
           'you want.</p>\n' +
         '<p>Thanks!<br>\nThe Janitor</p>\n';
       },
       textMessage (key) {
+        const url = baseUrl + '/?key=' + encodeURIComponent(key);
         return 'Hello,\n\n' +
         'To sign in to the Janitor, please visit the following URL:\n\n' +
-        'https://' + hostname + '/?key=' + key + '\n\n' +
+          url + '\n\n' +
         'This link will only work once, but you can get as many links as ' +
           'you want.\n\n' +
         'Thanks!\nThe Janitor\n';
@@ -141,6 +150,7 @@ exports.sendInviteEmail = function (email, callback) {
         return 'Janitor Invite';
       },
       htmlMessage (key) {
+        const url = baseUrl + '/settings/?key=' + encodeURIComponent(key);
         return '<p>You are invited to join the Alpha of the Janitor.</p>\n' +
         '<p>To activate your free and unlimited account, please follow the ' +
           'steps below:\n<ol>' +
@@ -149,14 +159,15 @@ exports.sendInviteEmail = function (email, callback) {
           'free)</li>\n' +
         '<li><a href="https://c9.io/account/ssh">Click here</a> to get your ' +
           'Cloud9 SSH public key</li>\n' +
-        '<li><a href="https://' + hostname + '/settings/?key=' + key + '">' +
-          'Click here</a> to access your Janitor account, then add ' +
-          'your Cloud9 username and your Cloud9 key</li></ol></p>\n' +
+        '<li><a href="' + url + '">Click here</a> to access your Janitor ' +
+          'account, then add your Cloud9 username and your Cloud9 key</li>' +
+          '</ol></p>\n' +
         '<p>With that, you will be able to clone and edit all the supported ' +
           'projects, as often and for as long as you like.</p>\n' +
         '<p>Happy hacking!<br>\nThe Janitor</p>\n';
       },
       textMessage (key) {
+        const url = baseUrl + '/settings/?key=' + encodeURIComponent(key);
         return 'You are invited to join the Alpha of the Janitor.\n\n' +
         'To activate your free and unlimited account, please follow the ' +
           'steps below:\n\n' +
@@ -166,8 +177,7 @@ exports.sendInviteEmail = function (email, callback) {
         '2. Get your Cloud9 SSH public key by visiting:\n' +
           'https://c9.io/account/ssh\n\n' +
         '3. Access your Janitor account, then add your Cloud9 username ' +
-          'and your Cloud9 key:\n' +
-          'https://' + hostname + '/settings/?key=' + key + '\n\n' +
+          'and your Cloud9 key:\n' + url + '\n\n' +
         'With that, you will be able to clone and edit all the supported ' +
           'projects, as often and for as long as you like.\n\n' +
         'Happy hacking!\nThe Janitor\n';

--- a/templates/header-insecure.html
+++ b/templates/header-insecure.html
@@ -1,0 +1,3 @@
+    <section class="alert alert-warning" role="alert">
+      <strong>Warning!</strong> Janitor was forced into <strong>insecure mode</strong>. Several security features have been disabled.
+    </section>


### PR DESCRIPTION
This pull request introduces two `db.json` security parameters:

```json
{
  "security": {
    "forceHttp": true,
    "forceInsecure": true
  }
}
```

They can be used by Janitor developers to completely disable HTTPS support, Let's Encrypt certificate generation, and several security policies (like hostname verification and some HTTP headers).

Additionally, forcing "insecure mode" adds an obvious warning message to all web pages, so that any accident on a production app becomes immediately visible to all users.

It also prints all sign-in keys in the server logs, because signing in via email is generally not an option when developing locally.

Note: I also sneaked in the unrelated `http.ServerResponse` bug fix again, respecting your nits from the previous pull request. Sorry for making the diff view confusing! (It might help to review comments separately).