### PR TITLE
Change the port to appropriate number when using HTTP and HTTPS for the console

### DIFF
--- a/app.js
+++ b/app.js
@@ -37,7 +37,7 @@ boot.executeInParallel([
   });
 
   log('[ok] Janitor → http' + (security.forceHttp ? '' : 's') + '://' +
-    hostname + ':' + ports.https);
+    hostname + ':' + (security.forceHttp ? ports.http : ports.https));
 
   // Protect the server and its users with a security policies middleware.
   const enforceSecurityPolicies = (request, response, next) => {


### PR DESCRIPTION
If you could take a look at the modification and test it for an HTTPS state that would be greatly appreciated. Unless this PR is breaking a feature ;)

**Problem**
I was running Janitor with `node app` and it says `http://localhost:8080` in the console. Port 8080 is the HTTPS port according to [db.json](https://github.com/JanitorTechnology/dockerfiles/blob/450ceb281b7ea460ec931edc9a3eaf0d4a18206f/janitor/db.json#L5). This would make it more challenging to simply click the link to navigate to the page.

**Solution**
I cloned the concept changing the link from `https://localhost:8080` to `http://localhost:8080` with regards to the port number. The expected result now is `https://localhost:8080` for HTTPS and `http://localhost:8081` for HTTP.