### PR TITLE
Ignore the  folder when making git commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.c9/*
 .DS_Store
 Thumbs.db
 npm-debug.log
@@ -11,4 +12,3 @@ janitor.log
 janitor.pid
 backups
 tokens
-.c9/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.c9/*
+.c9
 .DS_Store
 Thumbs.db
 npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ janitor.log
 janitor.pid
 backups
 tokens
+.c9/*


### PR DESCRIPTION
@jankeromnes I was working on submitting the last PR when I encountered files from the `.c9/` added to my list of watched files. I heard that `.gitignore` can prevent files and folders from being pushed upstream so I made an addition to the `.gitignore` file. Let me know what you think.