### PR TITLE
Make the web proxy re-send any previously consumed data chunks

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,6 +29,7 @@ boot.executeInParallel([
   // The main Janitor server.
   const app = camp.start({
     documentRoot: process.cwd() + '/static',
+    saveRequestChunks: true,
     port: ports.https,
     secure: !security.forceHttp,
     key: https.key,

--- a/join.js
+++ b/join.js
@@ -39,6 +39,7 @@ boot.executeInParallel([
     // Start an authenticated Janitor proxy for Docker containers on this host.
     const proxy = camp.start({
       documentRoot: process.cwd() + '/static',
+      saveRequestChunks: true,
       port: ports.https,
       secure: !security.forceHttp,
       key: https.key,

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -341,5 +341,10 @@ exports.webProxy = function (request, response, parameters) {
     response.end();
   });
 
+  // If we already consumed some request data, re-send it through the proxy.
+  if (request.savedChunks) {
+    proxy.write(request.savedChunks);
+  }
+
   request.pipe(proxy, { end: true });
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "stop": "if [ -e janitor.pid -a -n \"$(ps h $(cat janitor.pid))\" ] ; then kill $(cat janitor.pid) && printf \"[$(date -uIs)] Background process stopped (PID $(cat janitor.pid)).\\n\" ; fi ; rm -f janitor.pid"
   },
   "dependencies": {
-    "@jankeromnes/camp": "~16.2.16",
+    "@jankeromnes/camp": "~16.2.17",
     "dockerode": "~2.4.3",
     "email-login": "~1.0.1",
     "fast-json-patch": "~1.1.9",


### PR DESCRIPTION
This uses `saveRequestChunks`, a new ScoutCamp feature added in https://github.com/espadrine/sc/pull/60, and partially fixes #54.