### PR TITLE
Add an automatically generated API reference page to the website.

### DIFF
--- a/api/hosts-api.js
+++ b/api/hosts-api.js
@@ -1,17 +1,17 @@
 // Copyright © 2016 Jan Keromnes. All rights reserved.
 // The following code is covered by the AGPL-3.0 license.
 
-let selfapi = require('selfapi');
+const selfapi = require('selfapi');
 
-let db = require('../lib/db');
-let docker = require('../lib/docker');
-let hosts = require('../lib/hosts');
-let log = require('../lib/log');
-let machines = require('../lib/machines');
-let users = require('../lib/users');
+const db = require('../lib/db');
+const docker = require('../lib/docker');
+const hosts = require('../lib/hosts');
+const log = require('../lib/log');
+const machines = require('../lib/machines');
+const users = require('../lib/users');
 
 // API resource to manage Janitor cluster hosts.
-let hostsAPI = module.exports = selfapi({
+const hostsAPI = module.exports = selfapi({
   title: 'Hosts',
 
   beforeTests: (callback) => {
@@ -38,15 +38,15 @@ hostsAPI.get({
   description: 'List all cluster hosts owned by the authenticated user.',
 
   handler: (request, response) => {
-    let { user } = request;
+    const { user } = request;
     if (!users.isAdmin(user)) {
       response.statusCode = 403; // Forbidden
       response.json({ error: 'Unauthorized' });
       return;
     }
 
-    let list = [];
-    for (let hostname in db.get('hosts')) {
+    const list = [];
+    for (const hostname in db.get('hosts')) {
       list.push(hostname);
     }
 
@@ -61,13 +61,13 @@ hostsAPI.get({
 });
 
 // API sub-resource to manage a single cluster host.
-let hostAPI = hostsAPI.api('/:hostname');
+const hostAPI = hostsAPI.api('/:hostname');
 
 hostAPI.get({
   title: 'Get a single host',
 
   handler: (request, response) => {
-    let { hostname } = request.query;
+    const { hostname } = request.query;
     if (!hostname) {
       response.statusCode = 400; // Bad Request
       response.json({ error: 'Invalid hostname' });
@@ -75,9 +75,9 @@ hostAPI.get({
     }
 
     // Host OAuth2 authentication.
-    let authenticatedHostname = hosts.authenticate(request);
+    const authenticatedHostname = hosts.authenticate(request);
     if (authenticatedHostname && authenticatedHostname === hostname) {
-      let host = hosts.get(hostname);
+      const host = hosts.get(hostname);
       if (host) {
         response.json(host.properties);
         return;
@@ -85,9 +85,9 @@ hostAPI.get({
     }
 
     // User authentication.
-    let { user } = request;
+    const { user } = request;
     if (user && users.isAdmin(user)) {
-      let host = hosts.get(hostname);
+      const host = hosts.get(hostname);
       if (host) {
         response.json(host.properties);
         return;
@@ -121,7 +121,7 @@ hostAPI.post({
   description: 'Create a new host and add it to the cluster.',
 
   handler: (request, response) => {
-    let { hostname } = request.query;
+    const { hostname } = request.query;
     if (!hostname) {
       response.statusCode = 400; // Bad Request
       response.json({ error: 'Invalid hostname' });
@@ -129,14 +129,14 @@ hostAPI.post({
     }
 
     // Host OAuth2 authentication.
-    let authenticatedHostname = hosts.authenticate(request);
+    const authenticatedHostname = hosts.authenticate(request);
     if (authenticatedHostname && authenticatedHostname === hostname) {
       updateHost();
       return;
     }
 
     // User authentication.
-    let { user } = request;
+    const { user } = request;
     if (user && users.isAdmin(user)) {
       if (hosts.get(hostname)) {
         updateHost();
@@ -192,7 +192,7 @@ hostAPI.post({
       request.on('end', () => {
         let parameters = null;
         try {
-          parameters = JSON.parse(String(json));
+          parameters = JSON.parse(json);
         } catch (error) {
           response.statusCode = 400; // Bad Request
           response.json({ error: 'Problems parsing JSON' });
@@ -229,14 +229,14 @@ hostAPI.get('/credentials', {
   description: 'Show a host\'s OAuth2 client credentials.',
 
   handler: (request, response) => {
-    let { user } = request;
+    const { user } = request;
     if (!users.isAdmin(user)) {
       response.statusCode = 404;
       response.json({ error: 'Host not found' });
       return;
     }
 
-    let host = hosts.get(request.query.hostname);
+    const host = hosts.get(request.query.hostname);
     if (!host) {
       response.statusCode = 404;
       response.json({ error: 'Host not found' });
@@ -261,14 +261,14 @@ hostAPI.delete('/credentials', {
   description: 'Reset a host\'s OAuth2 client secret.',
 
   handler: (request, response) => {
-    let { user } = request;
+    const { user } = request;
     if (!users.isAdmin(user)) {
       response.statusCode = 404;
       response.json({ error: 'Host not found' });
       return;
     }
 
-    let host = hosts.get(request.query.hostname);
+    const host = hosts.get(request.query.hostname);
     if (!host) {
       response.statusCode = 404;
       response.json({ error: 'Host not found' });
@@ -296,14 +296,14 @@ hostAPI.get('/version', {
   title: 'Show host version',
 
   handler: (request, response) => {
-    let { user } = request;
+    const { user } = request;
     if (!users.isAdmin(user)) {
       response.statusCode = 404;
       response.json({ error: 'Host not found' });
       return;
     }
 
-    let { hostname } = request.query;
+    const { hostname } = request.query;
     if (!hosts.get(hostname)) {
       response.statusCode = 404;
       response.json({ error: 'Host not found' });

--- a/api/index.js
+++ b/api/index.js
@@ -1,18 +1,14 @@
 // Copyright © 2016 Jan Keromnes. All rights reserved.
 // The following code is covered by the AGPL-3.0 license.
 
-let selfapi = require('selfapi');
-
+const selfapi = require('selfapi');
 
 // Janitor API root resource.
-
-let api = selfapi({
-  title: 'Janitor API'
+const api = module.exports = selfapi({
+  title: 'Janitor API',
+  description:
+    'A simple JSON API to interact with Janitor containers, hosts and projects.'
 });
 
-module.exports = api;
-
-
 // Janitor API sub-resources.
-
 api.api('/hosts', require('./hosts-api'));

--- a/app.js
+++ b/app.js
@@ -90,6 +90,13 @@ boot.executeInParallel([
     routes.landingPage(query.res, user);
   });
 
+  // Public API reference.
+  app.route(/^\/reference\/api\/?$/, (data, match, end, query) => {
+    let { user } = query.req;
+    log('api reference');
+    routes.apiPage(query.res, api, user);
+  });
+
   // Public blog page.
   app.route(/^\/blog\/?$/, (data, match, end, query) => {
     const { user } = query.req;

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -81,6 +81,24 @@ exports.landingPage = function (response, user = null) {
   ]);
 };
 
+// Public API reference page.
+const apiSection = camp.template('./templates/reference-api.html');
+exports.apiPage = function (response, api, user = null) {
+  const title = 'API';
+  const htmlReference = api.toHTML();
+
+  response.template({
+    htmlReference,
+    title,
+    user,
+    scripts: []
+  }, [
+    appHeader,
+    apiSection,
+    appFooter
+  ]);
+};
+
 // Public blog page.
 const blogSection = camp.template('./templates/blog.html');
 exports.blogPage = function (response, user = null) {

--- a/static/css/janitor.css
+++ b/static/css/janitor.css
@@ -353,6 +353,26 @@ h4 {
   margin-right: -2px;
 }
 
+/* API reference */
+
+.reference h1:not(:first-of-type) {
+  margin-top: 55px;
+  margin-bottom: 10px;
+}
+
+.reference h2 {
+  border-bottom: 0;
+  font-size: 28px;
+  margin-top: 45px;
+  margin-bottom: 10px;
+}
+
+.reference h3 {
+  font-size: 20px;
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+
 /* Data */
 
 .data-topic {
@@ -398,6 +418,7 @@ section.contributions > .container,
 section.data > .container,
 section.login > .container,
 section.projects > .container,
+section.reference > .container,
 section.settings > .container,
 section.video > .container{
   max-width: 850px;

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -4,6 +4,7 @@
           <li><a href="https://github.com/janitortechnology/janitor/blob/master/LICENSE">&copy; The Janitor</a></li>
         </ul>
         <ul class="nav navbar-nav navbar-right">
+          <li><a href="/reference/api">API</a></li>
           <li><a href="/blog/">Blog</a></li>
           <li><a href="/data/">Data</a></li>
           <li><a href="https://github.com/janitortechnology/janitor">GitHub</a></li>

--- a/templates/reference-api.html
+++ b/templates/reference-api.html
@@ -1,0 +1,3 @@
+    <section class="reference">
+      <div class="container">{{= htmlReference }}</div>
+    </section>


### PR DESCRIPTION
This simple change just adds a small template that includes `api.toHTML()`, which is a basic HTML export of Janitor's live [SelfAPI](https://github.com/JanitorTechnology/selfapi) instance. I also added a few basic CSS rules to make these docs more readable.

The resulting page looks like this:

![janitor-api](https://cloud.githubusercontent.com/assets/599268/26154942/cfd239a8-3b11-11e7-9d09-e0c2c15d09ad.png)

Edit: I've also added another commit with a few minor fixes (coding style, API description).