### PR TITLE
Add an API to manage third-party OAuth2 providers.

### DIFF
--- a/api/admin-api.js
+++ b/api/admin-api.js
@@ -1,0 +1,107 @@
+// Copyright © 2017 Jan Keromnes. All rights reserved.
+// The following code is covered by the AGPL-3.0 license.
+
+const jsonpatch = require('fast-json-patch');
+const selfapi = require('selfapi');
+
+const db = require('../lib/db');
+const log = require('../lib/log');
+const users = require('../lib/users');
+
+// API resource to manage the Janitor instance itself.
+const adminAPI = module.exports = selfapi({
+  title: 'Admin'
+});
+
+// API sub-resource to manage OAuth2 providers.
+const oauth2providersAPI = adminAPI.api('/oauth2providers');
+
+oauth2providersAPI.get({
+  title: 'List OAuth2 providers',
+
+  handler: (request, response) => {
+    const { user } = request;
+    if (!user || !users.isAdmin(user)) {
+      response.statusCode = 403; // Forbidden
+      response.json({ error: 'Unauthorized' }, null, 2);
+      return;
+    }
+
+    const providers = db.get('oauth2providers');
+    response.json(providers, null, 2);
+  },
+
+  examples: [{
+    response: {
+      body: JSON.stringify({
+        provider: {
+          id: '1234',
+          secret: '123456',
+          hostname: 'host.name'
+        }
+      }, null, 2)
+    }
+  }]
+});
+
+// API sub-resource to manage a single OAuth2 provider.
+const oauth2providerAPI = oauth2providersAPI.api('/:provider');
+
+oauth2providerAPI.patch({
+  title: 'Update an OAuth2 provider',
+  description: 'Update an OAuth2 provider configuration (with JSON Patch).',
+
+  handler: (request, response) => {
+    const { user } = request;
+    if (!user || !users.isAdmin(user)) {
+      response.statusCode = 403; // Forbidden
+      response.json({ error: 'Unauthorized' }, null, 2);
+      return;
+    }
+
+    const { provider: providerId } = request.query;
+    const provider = db.get('oauth2providers')[providerId];
+    if (!provider) {
+      response.statusCode = 404;
+      response.json({ error: 'Provider not found' }, null, 2);
+      return;
+    }
+
+    let json = '';
+    request.on('data', chunk => {
+      json += String(chunk);
+    });
+    request.on('end', () => {
+      let operations = null;
+      try {
+        operations = JSON.parse(json);
+      } catch (error) {
+        log('[fail] json patch', error);
+        response.statusCode = 400; // Bad Request
+        response.json({ error: 'Problems parsing JSON' }, null, 2);
+        return;
+      }
+
+      // Apply the requested changes to the provider.
+      jsonpatch.apply(provider, operations);
+      db.save();
+      response.json(provider, null, 2);
+    });
+  },
+
+  examples: [{
+    request: {
+      urlParameters: { provider: 'provider' },
+      body: JSON.stringify([
+        { op: 'add', path: '/secret', value: '654321' }
+      ], null, 2)
+    },
+    response: {
+      body: JSON.stringify({
+        id: '1234',
+        secret: '654321',
+        hostname: 'host.name'
+      }, null, 2)
+    }
+  }]
+});

--- a/api/index.js
+++ b/api/index.js
@@ -12,3 +12,4 @@ const api = module.exports = selfapi({
 
 // Janitor API sub-resources.
 api.api('/hosts', require('./hosts-api'));
+api.api('/admin', require('./admin-api'));


### PR DESCRIPTION
This pull requests adds two API endpoints (that will be used in a follow-up pull request to support authentication via GitHub):
- List all OAuth2 provider configurations (their URLs and client credentials)
- Update an OAuth2 provider (accepting a JSON body formatted as an RFC 6902 JSON Patch array)

They should only be usable by website administrators (note the `users.isAdmin(user)` checks), and should fail otherwise.

The SelfAPI auto-generated documentation looks like this:
![admin-api-docs](https://cloud.githubusercontent.com/assets/599268/26207637/690daac2-3be8-11e7-87fe-8216f04ef140.png)

