### PR TITLE
Minor changes.

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -95,7 +95,7 @@ exports.resetSSHKeyPair = function (user) {
 exports.sendLoginEmail = function (email, request, callback) {
   sessions.get(request, (error, session, token) => {
     // Alpha version is invite-only.
-    if (!(email in db.get('users'))) {
+    if (!(email in db.get('users')) && !exports.isAdmin({ email })) {
       // Add unknown emails to the waitlist.
       const waitlist = db.get('waitlist');
       if (!(email in waitlist)) {


### PR DESCRIPTION
- I address a usability issue (helpful for developing Janitor in Janitor) that allows admin users to sign in without invitation. (Without this, one first needs to forcibly call `getOrCreate('admin@localhost')` in `/lib/users.js` before being able to sign in.)
- I include a few more commits from the [dockerfiles](https://github.com/JanitorTechnology/dockerfiles) repository in our submodule.