### PR TITLE
Add an API to manage users, and use it to edit real names

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -12,4 +12,5 @@ const api = module.exports = selfapi({
 
 // Janitor API sub-resources.
 api.api('/hosts', require('./hosts-api'));
+api.api('/user', require('./user-api'));
 api.api('/admin', require('./admin-api'));

--- a/api/user-api.js
+++ b/api/user-api.js
@@ -1,0 +1,78 @@
+// Copyright © 2017 Jan Keromnes. All rights reserved.
+// The following code is covered by the AGPL-3.0 license.
+
+const jsonpatch = require('fast-json-patch');
+const selfapi = require('selfapi');
+
+const db = require('../lib/db');
+
+// API resource to manage a Janitor user.
+const userAPI = module.exports = selfapi({
+  title: 'User'
+});
+
+userAPI.get({
+  title: 'Get the authenticated user',
+
+  handler: (request, response) => {
+    const { user } = request;
+    if (!user) {
+      response.statusCode = 403; // Forbidden
+      response.json({ error: 'Unauthorized' });
+      return;
+    }
+
+    response.json(user.profile, null, 2);
+  },
+
+  examples: [{
+    response: {
+      body: JSON.stringify({ name: 'User Name' }, null, 2)
+    }
+  }]
+});
+
+userAPI.patch({
+  title: 'Update the authenticated user',
+  description: 'Update the user\'s profile information (with JSON Patch).',
+
+  handler: (request, response) => {
+    const { user } = request;
+    if (!user) {
+      response.statusCode = 403; // Forbidden
+      response.json({ error: 'Unauthorized' });
+      return;
+    }
+
+    let json = '';
+    request.on('data', chunk => {
+      json += String(chunk);
+    });
+    request.on('end', () => {
+      let operations = null;
+      try {
+        operations = JSON.parse(json);
+      } catch (error) {
+        response.statusCode = 400; // Bad Request
+        response.json({ error: 'Problems parsing JSON' }, null, 2);
+        return;
+      }
+
+      jsonpatch.apply(user.profile, operations);
+      db.save();
+
+      response.json(user.profile, null, 2);
+    });
+  },
+
+  examples: [{
+    request: {
+      body: JSON.stringify([
+        { op: 'add', path: '/name', value: 'Different Name' }
+      ], null, 2)
+    },
+    response: {
+      body: JSON.stringify({ name: 'Different Name' }, null, 2)
+    }
+  }]
+});

--- a/lib/users.js
+++ b/lib/users.js
@@ -215,6 +215,9 @@ function getOrCreateUser (email) {
   if (!user) {
     user = {
       email: email,
+      profile: {
+        name: ''
+      },
       keys: {
         cloud9: '',
         cloud9user: '',
@@ -243,6 +246,13 @@ function getOrCreateUser (email) {
       publicKey: ''
     };
     exports.resetSSHKeyPair(user);
+  }
+
+  // Temporary migration code: Previous users didn't have a profile.
+  if (!user.profile) {
+    user.profile = {
+      name: ''
+    };
   }
 
   return user;

--- a/templates/settings-account.html
+++ b/templates/settings-account.html
@@ -1,11 +1,15 @@
     <section class="settings">
       <div class="container">
         <div class="row">
-          <div class="account-form col-sm-6">
+          <div class="account-form col-sm-4">
             <label>Email</label>
             <input class="form-control" disabled="true" type="text" value={{= user.email in json}}>
           </div>
-          <form id="cloud9user-form" class="account-form ajax-form has-feedback col-sm-6">
+          <form action="/api/user" class="account-form ajax-form has-feedback col-sm-4" method="patch">
+            <label class="control-label">Name</label>
+            <input class="form-control" data-submit-on="blur" name="/name" placeholder="Real name" type="text" value={{= user.profile.name in json}}>
+          </form>
+          <form id="cloud9user-form" class="account-form ajax-form has-feedback col-sm-4">
             <input type="hidden" name="name" value="cloud9user">
             <label class="control-label">Cloud9 Username</label>
             <input class="form-control" data-submit-on="blur" name="key" placeholder="Username" type="text" value={{= user.keys.cloud9user in json}}>


### PR DESCRIPTION
This pull request adds a `/api/user` endpoint which allows `GET` and `PATCH` operations to manage the current user's profile information.

Behind the scenes, it manages a newly introduced `user.profile = { name: '' }` object, which the user will be able to change at will. (In the future, it might contains things like avatar url, website, short bio, etc. if deemed useful).

The auto-generated User API docs look like this with this commit:

![user-api-docs](https://user-images.githubusercontent.com/599268/26870096-19ed3f52-4b6f-11e7-969e-b5724132512a.png)