### PR TITLE
Allow users to import basic account information from GitHub.

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -1,0 +1,171 @@
+// Copyright © 2017 Jan Keromnes. All rights reserved.
+// The following code is covered by the AGPL-3.0 license.
+
+const db = require('./db');
+const oauth2 = require('./oauth2');
+
+load();
+
+// Load our GitHub OAuth2 credentials.
+function load () {
+  const oauth2providers = db.get('oauth2providers');
+
+  // Add a non-functional, empty GitHub OAuth2 provider by default.
+  if (!oauth2providers.github) {
+    oauth2providers.github = {
+      id: '',
+      secret: '',
+      hostname: 'github.com',
+      api: 'api.github.com',
+    };
+  }
+}
+
+// Associate non-persistent OAuth2 states to sessions.
+const oauth2States = {};
+
+// Generate a URL allowing users to authorize us as a GitHub OAuth2 application.
+exports.getAuthorizationUrl = function (request, callback) {
+  const { session } = request;
+  if (!session || !session.id) {
+    callback(new Error('Request has no associated session'));
+    return;
+  }
+
+  // Generate a new OAuth2 state parameter for this authentication link.
+  oauth2.generateStateParameter((error, state) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+
+    oauth2States[session.id] = state;
+    const parameters = {
+      provider: 'github',
+      options: {
+        scope: [ 'user:email' ],
+        state,
+      }
+    };
+
+    oauth2.getAuthorizationUrl(parameters, (error, authorizeUrl) => {
+      callback(error, authorizeUrl);
+    });
+  });
+};
+
+// Exchange a GitHub OAuth2 authorization code against an access token.
+exports.authenticate = function (request, callback) {
+  const { session } = request;
+  if (!session || !session.id) {
+    callback(new Error('Request has no associated session'));
+    return;
+  }
+
+  const { state } = request.query;
+  const expectedState = oauth2States[session.id];
+  if (!state || String(state) !== String(expectedState)) {
+    callback(new Error('Bad state: Got ' + state + ' but expected ' +
+      expectedState));
+    return;
+  }
+
+  const { code } = request.query;
+  const parameters = {
+    provider: 'github',
+    code,
+    options: { state },
+  };
+
+  oauth2.getAccessToken(parameters, (error, accessToken, refreshToken) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+
+    delete oauth2States[session.id];
+    callback(null, accessToken, refreshToken);
+  });
+};
+
+// Perform an authenticated GitHub API request.
+exports.request = function (method, path, data, accessToken, callback) {
+  const parameters = {
+    provider: 'github',
+    accessToken,
+    method,
+    path,
+    data,
+    headers: {
+      'Accept': 'application/vnd.github.v3+json'
+    }
+  };
+
+  oauth2.request(parameters, (error, body, response) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+
+    const responseStatus = response.statusCode;
+    if (responseStatus < 200 || responseStatus >= 300) {
+      error = new Error('GitHub API response status: ' + responseStatus);
+    }
+
+    try {
+      const data = JSON.parse(body);
+      callback(error, data);
+    } catch (err) {
+      callback(error || err, body);
+    }
+  });
+};
+
+// Get the user's public profile information.
+// A `profile` object may contain information like:
+// {
+//   "login": "octocat",
+//   "name": "monalisa octocat",
+//   "blog": "https://github.com/blog",
+//   "location": "San Francisco",
+//   "bio": "There once was...",
+// }
+// See: https://developer.github.com/v3/users/#get-the-authenticated-user
+exports.getUserProfile = function (accessToken, callback) {
+  exports.request('GET', '/user', null, accessToken, (error, profile) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+
+    callback(null, profile);
+  });
+};
+
+// Get the user's verified email addresses.
+exports.getVerifiedEmails = function (accessToken, callback) {
+  exports.request('GET', '/user/emails', null, accessToken, (error, emails) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+
+    // Don't trust un-verified email addresses.
+    const verifiedEmails = emails.filter(email => email.verified);
+    callback(null, verifiedEmails);
+  });
+};
+
+// Get the user's authorized SSH public keys (doesn't require an access token).
+exports.getSSHPublicKeys = function (username, callback) {
+  const url = '/users/' + username + '/keys';
+
+  exports.request('GET', url, null, null, (error, sshPublicKeys) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+
+    callback(null, sshPublicKeys);
+  });
+};

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -6,6 +6,7 @@ const http = require('http');
 
 const configurations = require('./configurations');
 const db = require('./db');
+const github = require('./github');
 const log = require('./log');
 const metrics = require('./metrics');
 
@@ -233,7 +234,7 @@ const settingsSections = {
   integrations: camp.template('./templates/settings-integrations.html'),
   notifications: camp.template('./templates/settings-notifications.html'),
 };
-exports.settingsPage = function (response, section, user = null) {
+exports.settingsPage = function (request, response, section, user = null) {
   const title = 'Settings';
   const template = settingsSections[section];
   if (!template) {
@@ -242,21 +243,32 @@ exports.settingsPage = function (response, section, user = null) {
     return;
   }
 
-  const defaultConfigurations = Object.keys(configurations.defaults);
-  response.template({
-    defaultConfigurations,
-    section,
-    title,
-    user,
-    scripts: [
-      '/js/settings.js'
-    ]
-  }, [
-    appHeader,
-    settingsHeader,
-    template,
-    appFooter
-  ]);
+  github.getAuthorizationUrl(request, (error, authorizeUrl) => {
+    if (error) {
+      log('[fail] could not get github authorization url', error);
+    }
+
+    const defaultConfigurations = Object.keys(configurations.defaults);
+    const { username } = user.keys.github || {};
+    response.template({
+      defaultConfigurations,
+      github: {
+        username,
+        authorizeUrl
+      },
+      section,
+      title,
+      user,
+      scripts: [
+        '/js/settings.js'
+      ],
+    }, [
+      appHeader,
+      settingsHeader,
+      template,
+      appFooter,
+    ]);
+  });
 };
 
 // Live data page.
@@ -283,6 +295,7 @@ const adminHeader = camp.template('./templates/admin-header.html');
 const adminSections = {
   docker: camp.template('./templates/admin-docker.html'),
   hosts: camp.template('./templates/admin-hosts.html'),
+  integrations: camp.template('./templates/admin-integrations.html'),
   projects: camp.template('./templates/admin-projects.html'),
   users: camp.template('./templates/admin-users.html'),
 };
@@ -296,6 +309,7 @@ exports.adminPage = function (response, section, user) {
   }
 
   let hosts = null;
+  let oauth2providers = null;
   let projects = null;
   let users = null;
   let waitlist = null;
@@ -307,6 +321,10 @@ exports.adminPage = function (response, section, user) {
 
     case 'hosts':
       hosts = db.get('hosts');
+      break;
+
+    case 'integrations':
+      oauth2providers = db.get('oauth2providers');
       break;
 
     case 'projects':
@@ -322,6 +340,7 @@ exports.adminPage = function (response, section, user) {
 
   response.template({
     hosts,
+    oauth2providers,
     projects,
     users,
     waitlist,

--- a/lib/users.js
+++ b/lib/users.js
@@ -4,6 +4,7 @@
 const certificates = require('./certificates');
 const configurations = require('./configurations');
 const db = require('./db');
+const github = require('./github');
 const hosts = require('./hosts');
 const log = require('./log');
 const metrics = require('./metrics');
@@ -90,6 +91,52 @@ exports.resetSSHKeyPair = function (user) {
     user.keys.ssh.publicKey = keypair.publicKey;
     db.save();
   });
+};
+
+// Refresh a user's GitHub account details using an OAuth2 access token.
+exports.refreshGitHubAccount = function (user, accessToken, refreshToken) {
+  github.getUserProfile(accessToken, (error, profile) => {
+    if (error) {
+      log('[fail] could not get github username', error);
+      return;
+    }
+
+    const { login: username, name } = profile;
+    user.keys.github.username = username;
+    user.keys.github.accessToken = accessToken;
+    user.keys.github.refreshToken = refreshToken;
+    user.profile.name = user.profile.name || name;
+
+    db.save();
+
+    github.getSSHPublicKeys(username, (error, sshPublicKeys) => {
+      if (error) {
+        log('[fail] could not get github public keys', error);
+        return;
+      }
+
+      user.keys.github.authorizedKeys = sshPublicKeys;
+      db.save();
+    });
+  });
+};
+
+// Forget a user's GitHub account details, including any access tokens.
+exports.destroyGitHubAccount = function (user) {
+  user.keys.github = {
+    username: '',
+    accessToken: '',
+    refreshToken: '',
+    authorizedKeys: []
+  };
+  db.save();
+};
+
+// Forget a user's Cloud9 account details.
+exports.destroyCloud9Account = function (user) {
+  user.keys.cloud9 = '';
+  user.keys.cloud9user = '';
+  db.save();
 };
 
 // Send a single-use login link to the user's email address.
@@ -235,6 +282,12 @@ function getOrCreateUser (email) {
       keys: {
         cloud9: '',
         cloud9user: '',
+        github: {
+          username: '',
+          accessToken: '',
+          refreshToken: '',
+          authorizedKeys: []
+        },
         ssh: {
           fingerprint: '',
           privateKey: '',
@@ -289,6 +342,11 @@ function getOrCreateUser (email) {
         machine.project = projectId;
       }
     }
+  }
+
+  // Temporary migration code: Previous users didn't have GitHub credentials.
+  if (!('github' in user.keys)) {
+    exports.destroyGitHubAccount(user);
   }
 
   // Temporary migration code: Previous users didn't have configuration files.

--- a/templates/admin-header.html
+++ b/templates/admin-header.html
@@ -3,6 +3,7 @@
         <ul class="nav nav-tabs">
           <li role="presentation" {{if {{section === "docker"}} then {{class="active"}}}}><a href="/admin/docker/">Docker</a></li>
           <li role="presentation" {{if {{section === "hosts"}} then {{class="active"}}}}><a href="/admin/hosts/">Hosts</a></li>
+          <li role="presentation" {{if {{section === "integrations"}} then {{class="active"}}}}><a href="/admin/integrations/">Integrations</a></li>
           <li role="presentation" {{if {{section === "projects"}} then {{class="active"}}}}><a href="/admin/projects/">Projects</a></li>
           <li role="presentation" {{if {{section === "users"}} then {{class="active"}}}}><a href="/admin/users/">Users</a></li>
         </ul>

--- a/templates/admin-integrations.html
+++ b/templates/admin-integrations.html
@@ -1,0 +1,24 @@
+    <section>
+      <div class="container">
+        <div class="row">
+          <div class="col-sm-12 col-md-6">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <h4 class="project-title">GitHub</h4>
+              </div>
+              <div class="panel-body">
+                <form action="/api/admin/oauth2providers/github" class="ajax-form has-feedback has-submit" method="patch">
+                  <label class="control-label">Client ID</label>
+                  <input class="form-control" name="/id" type="text" value={{= oauth2providers.github.id in json}}>
+                  <br>
+                  <label class="control-label">Client Secret</label>
+                  <input class="form-control" name="/secret" type="text" value={{= oauth2providers.github.secret in json}}>
+                  <br>
+                  <input type="submit" class="btn btn-default" value="Update">
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>

--- a/templates/settings-integrations.html
+++ b/templates/settings-integrations.html
@@ -15,7 +15,7 @@
                   <small>Use the stunning Cloud9 IDE to hack on your projects</small>
                 </div>
                 <div class="list-group-item-controls">
-                  <a class="btn btn-default" href="/settings/account/"><span class="hidden-xs">Go to </span>Account</a>
+                  <a class="btn btn-default" href="/settings/account/">Manage<span class="hidden-xs"> Account</span></a>
                 </div>
               </li>
               <li class="list-group-item">
@@ -24,8 +24,11 @@
                   <strong><a href="https://github.com">GitHub</a></strong><br>
                   <small>Import basic information from your GitHub profile</small>
                 </div>
-                <div class="list-group-item-controls">
-                  <a class="btn btn-default disabled" disabled="true" href="#"><span class="hidden-xs">Coming </span>Soon&trade;</a>
+                <div class="list-group-item-controls">{{if {{github.username}} then {{
+                  <form action="/api/user/credentials/github" class="ajax-form has-feedback is-submit" data-refresh-after-success="true" method="delete">
+                    <button class="btn btn-default" type="submit">Disconnect</button>
+                  </form>}} else {{
+                  <a class="btn btn-default" href={{= github.authorizeUrl in json}}>Connect</a>}}}}
                 </div>
               </li>
               <li class="list-group-item">


### PR DESCRIPTION
When enabling the GitHub integration, the following profile data is imported:
- Username (public)
- Full name (public)
- SSH public keys (public)

We also plan to import verified email addresses in the future in order to
de-duplicate user accounts.