### PR TITLE
Fix deploying configuration files to all containers.

### DIFF
--- a/lib/machines.js
+++ b/lib/machines.js
@@ -288,20 +288,18 @@ exports.destroy = function (user, projectId, machineId, callback) {
 // Install or overwrite a configuration file in all the user's containers.
 exports.deployConfigurationInAllContainers = function (user, file) {
   let count = 0;
-  const userMachines = Object.values(user.machines)
-    .filter(m => m.status == 'started')
-    .reduce((acc, val) => acc.concat(val), []);
+  const machines = Object.values(user.machines)
+    .reduce((machines, projectMachines) => machines.concat(projectMachines), [])
+    .filter(machine => machine.status === 'started');
 
-  return Promise.all(userMachines.map(machine => {
+  return Promise.all(machines.map(machine => {
     const { container: containerId } = machine.docker;
-    if (containerId.length < 16 || !/^[0-9a-f]+$/.test(containerId)) {
-      log('[fail] invalid container id:', containerId);
-      // Continue deploying anyway.
-      return;
-    }
-
     return exports.deployConfiguration(user, machine, file).then(() => {
+      log('deploy-config', file, containerId.slice(0, 16), 'success');
       count++;
+    }).catch(error => {
+      log('[fail] deploy-config', file, containerId.slice(0, 16), error);
+      // Continue deploying to other containers anyway.
     });
   })).then(() => count);
 };
@@ -309,6 +307,10 @@ exports.deployConfigurationInAllContainers = function (user, file) {
 // Install or overwrite a configuration file in a given user container.
 exports.deployConfiguration = function (user, machine, file) {
   const { host, container: containerId } = machine.docker;
+  if (containerId.length < 16 || !/^[0-9a-f]+$/.test(containerId)) {
+    return Promise.reject(new Error('Invalid container ID: ' + containerId));
+  }
+
   return new Promise((resolve, reject) => {
     docker.copyIntoContainer({
       host,


### PR DESCRIPTION
The status `filter` was wrongly applied to the Array of project machines *before* they were `reduce`d to a single Array of machines. The structure looks like this:

```js
user.machines = {
  "firefox": [ machine0, machine1 ],
  "chromium": [ machine0 ],
}
```

The existing code was wrongly checking `[ machine0, machine1 ].status === 'started'`, which doesn't work because an Array has no "status" property.

The fix is to make multiple `machine0.status === 'started'` checks on all machines.