### PR TITLE
Use a random cookie name 2/2.

### DIFF
--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -36,7 +36,7 @@ exports.get = function (request, callback) {
   // Extract the session token from the cookies, if available.
   const cookies = request.headers.cookie || '';
   const cookie = cookies.split('; ').filter(cookie => {
-    return cookie.startsWith('token=');
+    return cookie.startsWith(cookieNames.token + '=');
   })[0];
   const token = cookie ? cookie.slice(6) : '';
 


### PR DESCRIPTION
Fix a forgotten hard-coded "token" cookie name that was left over from #94.