### PR TITLE
Accept '-' in project IDs for project page URLs.

### DIFF
--- a/app.js
+++ b/app.js
@@ -111,7 +111,7 @@ boot.executeInParallel([
   });
 
   // Public project pages.
-  app.route(/^\/projects(\/\w+)?\/?$/, (data, match, end, query) => {
+  app.route(/^\/projects(\/[\w-]+)?\/?$/, (data, match, end, query) => {
     const { user } = query.req;
     const projectUri = match[1];
     if (!projectUri) {


### PR DESCRIPTION
This would allow accessing https://janitor.technology/projects/firefox-hg/ (currently 404).