### PR TITLE
Automatically test the Janitor API against its own request/response examples.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ janitor.log
 janitor.pid
 backups
 tokens
+tests/db.json
+tests/templates

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - 8

--- a/lib/hosts.js
+++ b/lib/hosts.js
@@ -142,10 +142,12 @@ exports.resetOAuth2ClientSecret = function (host, callback) {
       return;
     }
 
+    if (!host.oauth2client) {
+      host.oauth2client = {};
+    }
     if (!host.oauth2client.id) {
       host.oauth2client.id = id;
     }
-
     host.oauth2client.secret = secret;
     db.save();
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "start": "if [ -z \"$SCRIPT\" ] ; then printf \"Run which Janitor script? [join/app]:\" && read SCRIPT ; fi ; node \"$SCRIPT\" >> janitor.log 2>&1 & printf \"$!\\n\" > janitor.pid",
     "poststart": "printf \"[$(date -uIs)] Background process started (PID $(cat janitor.pid), LOGS $(pwd)/janitor.log).\\n\"",
     "stop": "if [ -e janitor.pid -a -n \"$(ps h $(cat janitor.pid))\" ] ; then kill $(cat janitor.pid) && printf \"[$(date -uIs)] Background process stopped (PID $(cat janitor.pid)).\\n\" ; fi ; rm -f janitor.pid",
+    "test": "cd tests && node tests.js",
     "watch": "watch-run --initial --pattern 'app.js,package.json,api/**,lib/**,templates/**' --stop-on-error npm run app & tailf janitor.log -n 0"
   },
   "dependencies": {
@@ -35,13 +36,13 @@
     "node-forge": "~0.7.1",
     "oauth": "~0.9.15",
     "oauth2provider": "~0.0.2",
-    "selfapi": "~0.0.16",
+    "selfapi": "~0.1.0",
     "tar-stream": "~1.5.4"
   },
   "devDependencies": {
     "watch-run": "^1.2.5"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "camp": "~17.2.0",
     "dockerode": "~2.5.0",
-    "email-login": "~1.0.1",
+    "email-login": "~1.1.0",
     "fast-json-patch": "~2.0.3",
     "fleau": "~16.2.0",
     "le-acme-core": "~2.1.1",

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,0 +1,229 @@
+// Copyright © 2017 Jan Keromnes. All rights reserved.
+// The following code is covered by the AGPL-3.0 license.
+
+'use strict';
+
+const fs = require('fs');
+const net = require('net');
+const path = require('path');
+const selfapi = require('selfapi');
+
+if (path.basename(process.cwd()) !== 'tests') {
+  console.error('Warning: Tests need to run inside the tests/ folder.\n' +
+    '  This is to prevent interference between tests and production.\n' +
+    '  Teleporting to tests/ now.');
+  process.chdir('tests');
+}
+
+try {
+  fs.unlinkSync('./db.json');
+} catch (error) {
+  if (error.code !== 'ENOENT') {
+    console.error(error.stack);
+    process.exit(1);
+  }
+}
+
+try {
+  fs.symlinkSync('../templates', './templates', 'dir');
+} catch (error) {
+  if (error.code !== 'EEXIST') {
+    console.error(error.stack);
+    process.exit(1);
+  }
+}
+
+let tests = [];
+
+tests.push({
+  title: 'Janitor API self-tests',
+
+  test: (port, callback) => {
+    const db = require('../lib/db');
+    // Tell our fake Janitor app that it runs on the fake host "example.com":
+    db.get('hostname', 'example.com');
+    // Disable sending any emails (for invites or signing in):
+    db.get('mailer').block = true;
+    // Disable Let's Encrypt HTTPS certificate generation and verification:
+    db.get('security').forceHttp = true;
+    // Disable any security policies that could get in the way of testing:
+    db.get('security').forceInsecure = true;
+
+    const boot = require('../lib/boot');
+    const docker = require('../lib/docker');
+    const machines = require('../lib/machines');
+    const users = require('../lib/users');
+
+    // Fake several Docker methods for testing.
+    // TODO Maybe use a real Docker Remote API server (or a full mock) for more
+    // realistic tests?
+    docker.runContainer = function (parameters, callback) {
+      callback(null, { id: 'abcdef0123456789' }, '');
+    };
+    docker.copyIntoContainer = docker.execInContainer =
+      function (parameters, callback) {
+        callback();
+      };
+    docker.version = function (parameters, callback) {
+      callback(null, { Version: '17.06.0-ce' });
+    };
+
+    function registerTestUser (next) {
+      // Grant administrative privileges to the fake email "admin@example.com".
+      db.get('admins')['admin@example.com'] = true;
+      // Create the user "admin@example.com" by "sending" them an invite email.
+      users.sendInviteEmail('admin@example.com', error => {
+        if (error) {
+          callback(error);
+          return;
+        }
+        next();
+      });
+    }
+
+    function registerTestProject (next) {
+      machines.setProject({
+        'id': 'test-project',
+        '/name': 'Test Project',
+        '/docker/host': 'example.com'
+      });
+      next();
+    }
+
+    function registerTestContainer (next) {
+      const user = db.get('users')['admin@example.com'];
+      // Create a new user machine for the project "test-project".
+      machines.spawn(user, 'test-project', error => {
+        if (error) {
+          callback(error);
+          return;
+        }
+        next();
+      });
+    }
+
+    boot.executeInParallel([
+      boot.forwardHttp,
+      boot.ensureDockerTlsCertificates,
+      registerTestUser,
+      registerTestProject,
+    ], () => {
+      registerTestContainer(() => {
+        const camp = require('camp');
+        const app = camp.start({
+          documentRoot: process.cwd() + '/../static',
+          port: port
+        });
+
+        // Authenticate test requests with a server middleware.
+        const sessions = require('../lib/sessions');
+        app.handle((request, response, next) => {
+          sessions.get(request, (error, session, token) => {
+            if (error || !session || !session.id) {
+              console.error('[fail] session:', session, error);
+              response.statusCode = 500; // Internal Server Error
+              response.end();
+              return;
+            }
+            request.session = session;
+            if (!('client_secret' in request.query)) {
+              request.user = db.get('users')['admin@example.com'];
+            }
+            next();
+          });
+        });
+
+        // Mount the Janitor API.
+        const api = require('../api/');
+        selfapi(app, '/api', api);
+
+        // Test the API against its own examples.
+        api.test('http://localhost:' + port, (error, results) => {
+          if (error) {
+            callback(error);
+            return;
+          }
+
+          if (results.failed.length > 0) {
+            var total = results.passed.length + results.failed.length;
+            callback(results.passed.length + '/' + total + ' API test' +
+              (total === 1 ? '' : 's') + ' passed. Failed tests: ' +
+              JSON.stringify(results.failed, null, 2));
+            return;
+          }
+
+          callback();
+        });
+      });
+    });
+  }
+});
+
+/*
+tests.push({
+  title: 'Docker host joining the cluster',
+
+  test: (port, callback) => {
+    // TODO Start app (`node app` or similar)
+    // TODO Start cluster host (`node join` or similar, on different ports)
+    // TODO Verify that cluster registration works
+    // TODO verify that
+    callback(new Error('Not implemented yet'));
+  }
+});
+*/
+
+/**
+ * To add a new test, simply copy-paste and fill in the following code block:
+
+tests.push({
+  title: '',
+  test: (port, callback) => {
+    // test some things
+    // callback(error);
+  }
+});
+
+*/
+
+let nextPort = 9000;
+function getPort (callback) {
+  const port = nextPort++;
+  const server = net.createServer();
+  server.listen(port, (error) => {
+    server.once('close', () => callback(port));
+    server.close();
+  });
+  server.on('error', error => getPort(callback));
+}
+
+let unfinishedTests = tests.length;
+function reportTest (test, error) {
+  if (error) {
+    process.exitCode = 1;
+    console.error('[fail]', test.title);
+    console.error(...(error.stack ? [ error.stack ] : [ 'Error:', error ]));
+  } else {
+    console.log('[ok]', test.title);
+  }
+  unfinishedTests--;
+  if (unfinishedTests === 0) {
+    process.exit();
+  }
+}
+
+function runTest (test) {
+  getPort(port => {
+    try {
+      test.test(port, error => reportTest(test, error));
+    } catch (error) {
+      reportTest(test, error);
+    }
+  });
+}
+
+while (tests.length > 0) {
+  // Randomly take a test out of the tests array, and run it.
+  const test = tests.splice(Math.floor(Math.random() * tests.length), 1)[0];
+  runTest(test);
+}


### PR DESCRIPTION
This uses a semi-real Janitor server to mount the API, and runs all request/response examples against their respective handlers.

The only fake things are:
- A pre-registered `admin@example.com` admin user,
- A few simplified values (e.g. `.gitconfig` just contains `"[user]\nname = User"`),
- Some methods from `lib/docker.js` (because it's hard to test against a real Docker Remote API daemon or mock server)