### PR TITLE
Un-fork ScoutCamp, and upgrade a few other dependencies.

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 // Copyright © 2016 Jan Keromnes. All rights reserved.
 // The following code is covered by the AGPL-3.0 license.
 
-const camp = require('@jankeromnes/camp');
+const camp = require('camp');
 const nodepath = require('path');
 const selfapi = require('selfapi');
 

--- a/join.js
+++ b/join.js
@@ -1,7 +1,7 @@
 // Copyright © 2016 Jan Keromnes. All rights reserved.
 // The following code is covered by the AGPL-3.0 license.
 
-const camp = require('@jankeromnes/camp');
+const camp = require('camp');
 const http = require('http');
 const nodepath = require('path');
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,7 +1,7 @@
 // Copyright © 2015 Jan Keromnes. All rights reserved.
 // The following code is covered by the AGPL-3.0 license.
 
-const camp = require('@jankeromnes/camp');
+const camp = require('camp');
 const http = require('http');
 
 const configurations = require('./configurations');

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@jankeromnes/camp": "~16.2.17",
     "dockerode": "~2.5.0",
     "email-login": "~1.0.1",
-    "fast-json-patch": "~2.0.2",
+    "fast-json-patch": "~2.0.3",
     "fleau": "~16.2.0",
     "le-acme-core": "~2.1.0",
     "node-forge": "~0.7.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "stop": "if [ -e janitor.pid -a -n \"$(ps h $(cat janitor.pid))\" ] ; then kill $(cat janitor.pid) && printf \"[$(date -uIs)] Background process stopped (PID $(cat janitor.pid)).\\n\" ; fi ; rm -f janitor.pid"
   },
   "dependencies": {
-    "@jankeromnes/camp": "~16.2.17",
+    "camp": "~17.2.0",
     "dockerode": "~2.5.0",
     "email-login": "~1.0.1",
     "fast-json-patch": "~2.0.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "email-login": "~1.0.1",
     "fast-json-patch": "~2.0.3",
     "fleau": "~16.2.0",
-    "le-acme-core": "~2.1.0",
+    "le-acme-core": "~2.1.1",
     "node-forge": "~0.7.1",
     "oauth": "~0.9.15",
     "oauth2provider": "~0.0.2",


### PR DESCRIPTION
Hooray! We're finally switching our server back to [camp](https://www.npmjs.com/package/camp) from the infamous [@jankeromnes/camp](https://www.npmjs.com/package/@jankeromnes/camp) fork introduced in a8df359f058c5480cbd730c089f9478ae0df5397 and c11bb4280bbeb73b071b7f8cbc4a0570d16f4b7e!