### PR TITLE
Tag internal Docker images with ':janitor-production'.

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -74,9 +74,48 @@ exports.buildImage = function (parameters, callback) {
   });
 };
 
+// Pull a Docker image into a given host.
+exports.pullImage = function (parameters, callback) {
+  const { host, image: imageId } = parameters;
+
+  getDocker(host, (error, docker) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+
+    docker.pull(imageId, function (error, stream) {
+      if (error) {
+        callback(error);
+        return;
+      }
+
+      callback(null, stream);
+    });
+  });
+};
+
+// Tag a Docker image in a given host.
+exports.tagImage = function (parameters, callback) {
+  const { host, image: imageId, tag: tagId } = parameters;
+
+  getDocker(host, (error, docker) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+
+    const image = docker.getImage(imageId);
+    const [ repo, tag = 'latest' ] = tagId.split(':');
+    image.tag({ repo, tag }, (error, data) => {
+      callback(error);
+    });
+  });
+};
+
 // Delete a Docker image from a given host.
 exports.removeImage = function (parameters, callback) {
-  let { host, image: imageId } = parameters;
+  const { host, image: imageId } = parameters;
 
   getDocker(host, (error, docker) => {
     if (error) {

--- a/lib/machines.js
+++ b/lib/machines.js
@@ -125,11 +125,10 @@ exports.update = function (projectId, callback) {
     return;
   }
 
-  const { host, image, update: dockerfile } = project.docker;
-  const tag = image + ':latest';
+  const { host, update: dockerfile, _productionImage: image } = project.docker;
   const time = Date.now();
 
-  docker.buildImage({ host, tag, dockerfile }, (error, stream) => {
+  docker.buildImage({ host, tag: image, dockerfile }, (error, stream) => {
     if (error) {
       log('update', image, error);
       callback(new Error('Unable to update project: ' + projectId));
@@ -137,7 +136,6 @@ exports.update = function (projectId, callback) {
     }
 
     log('update', image, 'started');
-
     streams.set(project.docker, 'logs', stream);
 
     stream.on('error', err => {
@@ -184,7 +182,7 @@ exports.spawn = function (user, projectId, callback) {
     };
   }
 
-  const { host, image } = project.docker;
+  const { host, _productionImage: image } = project.docker;
   const time = Date.now();
 
   log('spawn', image, 'started');
@@ -474,5 +472,18 @@ function getProject (projectId, create) {
     db.save();
   }
 
-  return project || null;
+  if (!project) {
+    return null;
+  }
+
+  // Get a hidden internal Docker image tagged with ':janitor-production'.
+  if (!project.docker.hasOwnProperty('_productionImage')) {
+    Object.defineProperty(project.docker, '_productionImage', {
+      get () {
+        return this.image.split(':')[0] + ':janitor-production';
+      }
+    });
+  }
+
+  return project;
 }


### PR DESCRIPTION
This change makes Janitor use the internal Docker tag `:janitor-production` for image updates and container spawns.

Previously, the default tag `:latest` was used for that, which caused the need for base images to use a different tag (e.g. `:base`).

As previously discussed on IRC, this wasn't convenient for most Docker Hub users out there wishing to add their projects to Janitor. So this change replaces the internal tag of `:latest` with an explicit `:janitor-production`, and allows using any base image tag instead of `:base` (i.e. you can now call base images `:latest`, or `:nightly`, or `:stable`, or `:1.0.5`, or anything you like except `:janitor-production`).

Note: The reason we need an external tag and an internal tag that's different is for building incremental image updates (we wish to build all incremental updates on top of the same base image, otherwise update layers would be chained indefinitely, causing very large Docker images).