### PR TITLE
Remove deprecated project rebuild feature.

### DIFF
--- a/app.js
+++ b/app.js
@@ -423,28 +423,6 @@ boot.executeInParallel([
     end({ status: 'success' });
   });
 
-  // Rebuild the base image of a project.
-  app.ajax.on('rebuild', (data, end, query) => {
-    const { user } = query.req;
-    if (!users.isAdmin(user)) {
-      end();
-      return;
-    }
-
-    machines.rebuild(data.project, error => {
-      if (error) {
-        end({ status: 'error', message: String(error) });
-        return;
-      }
-      end({ status: 'success' });
-    });
-
-    // For longer requests, make sure we reply before the browser retries.
-    setTimeout(() => {
-      end({ status: 'started' });
-    }, 42000);
-  });
-
   // Update the base image of a project.
   app.ajax.on('update', (data, end, query) => {
     const { user } = query.req;

--- a/lib/machines.js
+++ b/lib/machines.js
@@ -143,51 +143,6 @@ exports.pull = function (projectId, callback) {
   });
 };
 
-// FIXME: Remove this deprecated method (and use `exports.pull` instead).
-// Rebuild the base image of a project. (Slow)
-exports.rebuild = function (projectId, callback) {
-  const project = getProject(projectId);
-  if (!project) {
-    callback(new Error('Unknown project: ' + projectId));
-    return;
-  }
-
-  const { host, image, build: dockerfile } = project.docker;
-  const tag = image + ':base';
-  const time = Date.now();
-
-  docker.buildImage({ host, tag, dockerfile }, (error, stream) => {
-    if (error) {
-      log('[fail] rebuild', image, error);
-      callback(new Error('Unable to rebuild project: ' + projectId));
-      return;
-    }
-
-    log('rebuild', image, 'started');
-
-    streams.set(project.docker, 'logs', stream);
-
-    stream.on('error', err => {
-      log('rebuild', image, err);
-      error = err;
-    });
-
-    stream.on('end', () => {
-      if (error) {
-        log('rebuild', image, error);
-        callback(new Error('Problem while rebuilding project: ' + projectId));
-        return;
-      }
-
-      log('rebuild', image, 'success');
-      const now = Date.now();
-      metrics.set(project, 'updated', now);
-      metrics.push(project, 'build-time', [ now, now - time ]);
-      callback();
-    });
-  });
-};
-
 // Build an incremental Docker image update for a project.
 exports.update = function (projectId, callback) {
   const project = getProject(projectId);
@@ -533,7 +488,6 @@ function getProject (projectId, create) {
             proxy: 'https'
           }
         },
-        build: '',
         update: '',
         logs: ''
       },

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -38,7 +38,7 @@ ajaxForm('#newproject-form', 'projectdb', function (form, data) {
   updateFormStatus(form, status, message);
 });
 
-// Project rebuild/update buttons.
+// Project update buttons.
 Array.map(document.querySelectorAll('button[data-action]'), function (button) {
   button.addEventListener('click', Scout.send(function (query) {
     query.action = button.dataset.action;

--- a/templates/admin-projects.html
+++ b/templates/admin-projects.html
@@ -11,7 +11,6 @@
               <form action="/api/projects/{{= id in xmlattr}}/pull" class="ajax-form has-feedback is-submit" method="post">
                 <button class="btn btn-default" type="submit">Pull</button>
               </form>
-              <button data-action="rebuild" data-project={{= id in json}} class="btn btn-default">Rebuild</button>
               <button data-action="update" data-project={{= id in json}} class="btn btn-primary">Update</button>
             </div>
           </div>
@@ -39,11 +38,6 @@
                 <input class="form-control" data-submit-on="blur" name="/docker/path" value={{= project.docker.path in json}}>
               </form>
             </div>
-            <form id="{{= id in xmlattr}}-build" data-action="projectdb" class="ajax-form has-feedback">
-              <input type="hidden" name="id" value={{= id in json}}>
-              <label class="control-label">Build</label>
-              <textarea class="form-control" data-submit-on="blur" name="/docker/build" rows="9">{{= project.docker.build in html}}</textarea>
-            </form>
             <form id="{{= id in xmlattr}}-update" data-action="projectdb" class="ajax-form has-feedback">
               <input type="hidden" name="id" value={{= id in json}}>
               <label class="control-label">Update</label>


### PR DESCRIPTION
We can now use `Pull` to download up-to-date project Docker images from Docker Hub, instead of building them ourself. (We were doing that manually anyway, since our admin interface doesn't support local `ADD` Dockerfile instructions).

It's still possible to build incremental update layers using the `Update` button, and this can be a good option to provide more frequent project updates and save disk space by limiting the number of different base image versions used in production.