### PR TITLE
Fix local proxy by routing WebSocket requests to mapped ports.

### DIFF
--- a/app.js
+++ b/app.js
@@ -384,8 +384,10 @@ boot.executeInParallel([
         return;
       }
 
-      const path = nodepath.normalize(request.url);
-      routes.webProxy(request, socket, { port, path });
+      routes.webProxy(request, socket, {
+        port: mappedPort.port,
+        path: nodepath.normalize(request.url)
+      });
     });
   });
 


### PR DESCRIPTION
Small bit of fall out from #124, which was affecting WebSocket proxy requests to janitor.technology itself (so remote servers like moz1.janitor.technology weren't affected).