### PR TITLE
Make the Docker host administration page editable again.

### DIFF
--- a/static/css/janitor.css
+++ b/static/css/janitor.css
@@ -242,12 +242,9 @@ h4 {
   right: 25px;
 }
 
-.ajax-form:not(.has-success) > .form-control-feedback > .glyphicon-ok {
-  display: none;
-}
-
+.ajax-form:not(.has-success) > .form-control-feedback > .glyphicon-ok,
 .ajax-form:not(.has-error) > .form-control-feedback > .glyphicon-remove {
-  display: none;
+  visibility: hidden;
 }
 
 .login-with {

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -22,6 +22,25 @@ ajaxForm('#invite-form', 'invite', function (form, data) {
   updateFormStatus(form, status, message);
 });
 
+// New host form.
+var newHostForm = document.querySelector('#newhost-form');
+if (newHostForm) {
+  window.setupAsyncForm(newHostForm);
+  newHostForm.addEventListener('submit', function (event) {
+    var hostname = newHostForm.elements.hostname.value;
+    window.fetchAPI('POST', '/api/hosts/' + hostname, {}, function (error, data) {
+      if (error) {
+        updateFormStatus(newHostForm, 'error', String(error));
+        return;
+      }
+      updateFormStatus(newHostForm, 'success', data ? data.message : null);
+      setTimeout(function () {
+        location.reload();
+      }, 400);
+    });
+  });
+}
+
 // New project form.
 ajaxForm('#newproject-form', 'projectdb', function (form, data) {
   var status = 'error';

--- a/static/js/janitor.js
+++ b/static/js/janitor.js
@@ -88,16 +88,21 @@ function ajaxForm (selector, action, callback) {
 // Use `window.fetch()` to make an asynchronous Janitor API request.
 function fetchAPI (method, url, data, callback) {
   var responseStatus = null;
-
-  window.fetch(url, {
+  var options = {
     method: method.toUpperCase(),
     headers: new Headers({
       'Accept': 'application/json',
       'Content-Type': 'application/json'
     }),
-    credentials: 'same-origin',
-    body: JSON.stringify(data, null, 2)
-  }).then(function (response) {
+    credentials: 'same-origin'
+  };
+
+  // Requests with method 'GET' or 'HEAD' cannot have `options.body`.
+  if (data && ['GET', 'HEAD'].indexOf(options.method) < 0) {
+    options.body = JSON.stringify(data, null, 2);
+  }
+
+  window.fetch(url, options).then(function (response) {
     // The server is responding!
     responseStatus = response.status;
     return responseStatus === 204 ? null : response.json();

--- a/templates/admin-hosts.html
+++ b/templates/admin-hosts.html
@@ -1,7 +1,7 @@
     <section>
       <div class="container">{{
-          for (let hostname in hosts) {
-            let host = hosts[hostname];
+          for (const hostname in hosts) {
+            const host = hosts[hostname];
         }}
         <div class="panel panel-default panel-project">
           <div class="panel-heading">
@@ -10,39 +10,56 @@
             <div class="project-actions"></div>
           </div>
           <div class="panel-body">
-            <div class="row">
-              <div class="col-sm-6">
-                <label class="control-label">Docker Remote API port</label>
-                <input class="form-control" disabled="true" type="number" value={{= host.properties.port in json}}>
+            <form action="/api/hosts/{{= hostname in xmlattr}}" class="ajax-form has-feedback" method="post">
+              <div class="row">
+                <div class="col-sm-6">
+                  <label class="control-label">Docker Remote API port</label>
+                  <input class="form-control" data-submit-on="blur" name="port" placeholder="2376" type="number" value={{= host.properties.port in json}}>
+                </div>
               </div>
-            </div>
-            <div class="row">
-              <div class="col-sm-4">
-                <label class="control-label">Docker TLS ca</label>
-                <textarea class="form-control" disabled="true" placeholder="-----BEGIN CERTIFICATE-----" rows="6">{{= host.properties.ca in html}}</textarea>
+              <div class="row">
+                <div class="col-sm-4">
+                  <label class="control-label">Docker TLS ca</label>
+                  <textarea class="form-control" data-submit-on="blur" name="ca" placeholder="-----BEGIN CERTIFICATE-----" rows="6">{{= host.properties.ca in html}}</textarea>
+                </div>
+                <div class="col-sm-4">
+                  <label class="control-label">Docker TLS certificate</label>
+                  <textarea class="form-control" data-submit-on="blur" name="crt" placeholder="-----BEGIN CERTIFICATE-----" rows="6">{{= host.properties.crt in html}}</textarea>
+                </div>
+                <div class="col-sm-4">
+                  <label class="control-label">Docker TLS key</label>
+                  <textarea class="form-control" data-submit-on="blur" name="key" placeholder="-----BEGIN RSA PRIVATE KEY-----" rows="6">{{= host.properties.key in html}}</textarea>
+                </div>
               </div>
-              <div class="col-sm-4">
-                <label class="control-label">Docker TLS certificate</label>
-                <textarea class="form-control" disabled="true" placeholder="-----BEGIN CERTIFICATE-----" rows="6">{{= host.properties.crt in html}}</textarea>
+            </form>
+          </div>{{if {{'oauth2client' in host}} then {{
+          <div class="panel-footer">
+            <form action="/api/hosts/{{= hostname in xmlattr}}/credentials" class="ajax-form has-feedback has-submit" data-refresh-after-success="true" method="delete">
+              <div class="row">
+                <div class="col-sm-6">
+                  <label class="control-label">OAuth2 ID</label>
+                  <input class="form-control" disabled="true" type="text" value={{= host.oauth2client.id in json}}>
+                </div>
+                <div class="col-sm-6">
+                  <label class="control-label">OAuth2 secret</label>
+                  <input class="form-control" disabled="true" type="text" value={{= host.oauth2client.secret in json}}>
+                </div>
               </div>
-              <div class="col-sm-4">
-                <label class="control-label">Docker TLS key</label>
-                <textarea class="form-control" disabled="true" placeholder="-----BEGIN RSA PRIVATE KEY-----" rows="6">{{= host.properties.key in html}}</textarea>
-              </div>
-            </div>{{if {{'oauth2client' in host}} then {{
-            <div class="row">
-              <div class="col-sm-6">
-                <label class="control-label">OAuth2 ID</label>
-                <input class="form-control" disabled="true" type="text" value={{= host.oauth2client.id in json}}>
-              </div>
-              <div class="col-sm-6">
-                <label class="control-label">OAuth2 secret</label>
-                <input class="form-control" disabled="true" type="text" value={{= host.oauth2client.secret in json}}>
-              </div>
-            </div>}}}}
-          </div>
+              <button class="btn btn-default" type="submit">Reset OAuth2 secret</button>
+            </form>
+          </div>}}}}
         </div>{{
           }
         }}
+        <div class="row">
+          <form class="ajax-form has-feedback has-button col-sm-12" id="newhost-form">
+            <label class="control-label">New Host</label>
+            <div class="input-group">
+              <input class="form-control" name="hostname" placeholder="example.com" type="text">
+              <span class="input-group-btn">
+                <button class="btn btn-primary" type="submit">Add</button>
+              </span>
+            </div>
+          </form>
       </div>
     </section>


### PR DESCRIPTION
The Docker hosts administration section became read-only when the old Ajax API was deprecated.

This change updates it to the new JSON API using `window.fetch`, and is helpful to manage Docker hosts (e.g. to add new remote hosts, or to update the TLS certificates, etc).

@nt1m, please have a look to double-check I haven't made any mistakes, or forgotten anything while updating this page. (In theory, it works, because I was successful at using it locally to set up and remote control janitor.technology's Docker host).