### PR TITLE
Add an API to list Docker images and containers on a host.

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -32,6 +32,22 @@ function getDocker (hostname, callback) {
   callback(null, docker);
 }
 
+// List all Docker images on a given host.
+exports.listImages = function (parameters, callback) {
+  const { host } = parameters;
+
+  getDocker(host, (error, docker) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+
+    docker.listImages({ all: 1 }, (error, images) => {
+      callback(error, images);
+    });
+  });
+};
+
 // Build a Docker image from a given Dockerfile.
 exports.buildImage = function (parameters, callback) {
   const { host, tag, dockerfile } = parameters;
@@ -143,6 +159,22 @@ exports.removeImage = function (parameters, callback) {
     const image = docker.getImage(imageId);
     image.remove((error, data) => {
       callback(error);
+    });
+  });
+};
+
+// List all Docker containers on a given host.
+exports.listContainers = function (parameters, callback) {
+  const { host } = parameters;
+
+  getDocker(host, (error, docker) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+
+    docker.listContainers({ all: 1 }, (error, containers) => {
+      callback(error, containers);
     });
   });
 };


### PR DESCRIPTION
These administrator-only API handlers will be useful in order to find out what's taking so much disk space on a Docker host.

I'm hoping to use it in a follow-up pull request to build a Docker admin interface that shows which images and containers take up the most disk space (e.g. as a tree), and that allows inspecting containers (to see if they contain anything valuable) and deleting them if they're useless to free up disk space.