### PR TITLE
Transition Cloud9 IDE links from c9.io to the SDK installed in each container.

### DIFF
--- a/templates/contributions.html
+++ b/templates/contributions.html
@@ -27,13 +27,23 @@
               <a class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
               </a>
-              <ul class="dropdown-menu">
+              <ul class="dropdown-menu">{{
+                const updated = new Date(machine.data.updated);
+                const c9sdkStart = new Date('2017-08-02');
+                const c9ioEnd = new Date('2017-09-02');
+                if (updated > c9sdkStart && updated < c9ioEnd) { }}
+                <li>
+                  <a href="https://c9.io/open/ssh?name={{= projectId in id}}-{{= id in id}}&description={{= project.name in uri}}%20on%20janitor.technology&host={{= machine.docker.host in uri}}&port={{= machine.docker.ports['22'].port in integer}}&user=user&workspaceDir={{= project.docker.path in uri}}&nodePath=%2Fhome%2Fuser%2F.c9%2Fnode%2Fbin%2Fnode" target="_blank">Edit via c9.io</a>
+                </li>{{ } }}
                 <li>
                   <a data-confirm="Delete {{= name in html}}?" data-details="This action can't be undone, please make sure you've backed up everything valuable." data-form-action="/api/hosts/{{= machine.docker.host in xmlattr}}/containers/{{= machine.docker.container in xmlattr}}" data-toggle="modal" data-target="#confirm" href="#">Delete</a>
                 </li>
               </ul>
               <a class="btn btn-default" href="https://{{= machine.docker.host in uri}}/{{= machine.docker.container.slice(0,16) in uri}}/8088/vnc.html" target="_blank">VNC</a>
-              <a class="btn btn-primary" href="https://c9.io/open/ssh?name={{= projectId in id}}-{{= id in id}}&description={{= project.name in uri}}%20on%20janitor.technology&host={{= machine.docker.host in uri}}&port={{= machine.docker.ports['22'].port in integer}}&user=user&workspaceDir={{= project.docker.path in uri}}&nodePath=%2Fhome%2Fuser%2F.c9%2Fnode%2Fbin%2Fnode" target="_blank"><span class="hidden-xs">Edit in </span>Cloud9</a>
+              <a class="btn btn-primary"{{
+                if (updated < c9sdkStart) { }} href="https://c9.io/open/ssh?name={{= projectId in id}}-{{= id in id}}&description={{= project.name in uri}}%20on%20janitor.technology&host={{= machine.docker.host in uri}}&port={{= machine.docker.ports['22'].port in integer}}&user=user&workspaceDir={{= project.docker.path in uri}}&nodePath=%2Fhome%2Fuser%2F.c9%2Fnode%2Fbin%2Fnode" {{ }
+                else { }} href="https://{{= machine.docker.host in uri}}/{{= machine.docker.container.slice(0,16) in uri}}/8089/ide.html" {{ }
+              }}target="_blank"><span class="hidden-xs">Edit in </span>Cloud9</a>
             </div>
           </div>
           <div class="panel-body">

--- a/templates/contributions.html
+++ b/templates/contributions.html
@@ -2,11 +2,14 @@
       <div class="container">
         <h2 class="header">My Contributions</h2>{{
           for (let projectId in user.machines) {
-            let machines = user.machines[projectId];
-            let project = projects[projectId];
-            for (let id in machines) {
-              let machine = machines[id];
-              if (machine.status === "new") continue;
+            const machines = user.machines[projectId];
+            const project = projects[projectId];
+            for (const id in machines) {
+              const machine = machines[id];
+              if (machine.status === "new") {
+                continue;
+              }
+              const name = machine.properties.name || `${project.name} #${id}`;
         }}
         <div class="panel panel-default panel-project">
           <div class="panel-heading">
@@ -16,12 +19,7 @@
                 <input class="form-control" data-submit-on="blur" name="/name" placeholder="{{= project.name in xmlattr }} #{{= id in id}}" type="text" value="{{= machine.properties.name in xmlattr }}">
               </form>
               <div class="editable-value">
-                <h4>
-                {{if (machine.properties.name)
-                    then {{{{= machine.properties.name in html}}}}
-                    else {{{{= project.name in html}} #{{= id in id}}}}
-                }}
-                </h4>
+                <h4>{{= name in html}}</h4>
                 <span class="glyphicon glyphicon-pencil editable-toggle"></span>
               </div>
             </div>
@@ -30,7 +28,9 @@
                 <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>
               </a>
               <ul class="dropdown-menu">
-                <li><a data-confirm="Delete {{= project.name in html}} #{{= id in id}}?" data-details="This action can't be undone, please make sure you've backed up everything valuable." data-form-action="/api/hosts/{{= machine.docker.host in xmlattr}}/containers/{{= machine.docker.container in xmlattr}}" data-toggle="modal" data-target="#confirm" href="#">Delete</a></li>
+                <li>
+                  <a data-confirm="Delete {{= name in html}}?" data-details="This action can't be undone, please make sure you've backed up everything valuable." data-form-action="/api/hosts/{{= machine.docker.host in xmlattr}}/containers/{{= machine.docker.container in xmlattr}}" data-toggle="modal" data-target="#confirm" href="#">Delete</a>
+                </li>
               </ul>
               <a class="btn btn-default" href="https://{{= machine.docker.host in uri}}/{{= machine.docker.container.slice(0,16) in uri}}/8088/vnc.html" target="_blank">VNC</a>
               <a class="btn btn-primary" href="https://c9.io/open/ssh?name={{= projectId in id}}-{{= id in id}}&description={{= project.name in uri}}%20on%20janitor.technology&host={{= machine.docker.host in uri}}&port={{= machine.docker.ports['22'].port in integer}}&user=user&workspaceDir={{= project.docker.path in uri}}&nodePath=%2Fhome%2Fuser%2F.c9%2Fnode%2Fbin%2Fnode" target="_blank"><span class="hidden-xs">Edit in </span>Cloud9</a>


### PR DESCRIPTION
## An update on how we use Cloud9 IDE for Janitor

We consider that every Janitor container, based on an image that was updated after August 2nd 2017, will ship with a working Cloud9 SDK running on port 8089.

However, we allow for a smooth transition period, by keeping a link to access Cloud9 SSH workspaces on the third-party service https://c9.io until September 1st 2017.

After September 1st, any pre-existing c9.io SSH workspaces will still work, but we'd like our users to not create new ones, and use the Cloud9 SDK on port 8089 instead (which is both faster to load and more stable).

Eventually, we'd like to stop relying on the https://c9.io third-party service, in order to support only our customized Cloud9 SDK. This will greatly simplify user registration, container creation, IDE access, IDE customization (with automated workflows for each supported project), and more.

We would like to warmly thank the [Cloud9 IDE](https://c9.io) team for supporting Janitor so very generously by letting us use this incredible product for free, and for their relentless help and guidance in helping us install, optimize and personalize the Cloud9 SDK for Janitor.

You guys rock! 👍 💯 🥇 🎆 ❤️ 🚀 ☁️