### PR TITLE
Removed margin from alert divs

### DIFF
--- a/static/css/janitor.css
+++ b/static/css/janitor.css
@@ -576,6 +576,7 @@ section.video {
   margin: 0;
 }
 
+/* Override bootstrap alert margin */
 .alert {
-  margin: 0;
+  margin-bottom: 0;
 }

--- a/static/css/janitor.css
+++ b/static/css/janitor.css
@@ -575,3 +575,7 @@ section.video {
   text-align: center;
   margin: 0;
 }
+
+.alert {
+  margin: 0;
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16819670/29422428-b15ee6a8-8367-11e7-9c89-7afc83ab1b28.png)
Margin creates ^ gap between the jumbotron and alert div, which doesn't look right.

After removing margin:
![image](https://user-images.githubusercontent.com/16819670/29422735-aa128bba-8368-11e7-9112-903cee0fd1a6.png)
