### PR TITLE
Add a feature to list changed files in a container (docker diff).

### DIFF
--- a/api/hosts-api.js
+++ b/api/hosts-api.js
@@ -602,8 +602,9 @@ containerAPI.get('/changes', {
     }
 
     const { hostname } = request.query;
+    // FIXME: For admins, find the machine regardless of which user owns it.
     const machine = machines.getMachineByContainer(user, hostname, container);
-    if (!machine) {
+    if (!machine && !users.isAdmin(user)) {
       response.statusCode = 404; // Not Found
       response.json({ error: 'Container not found' }, null, 2);
       return;
@@ -627,7 +628,7 @@ containerAPI.get('/changes', {
       urlParameters: {
         hostname: 'example.com',
         container: 'abcdef0123456789',
-      },
+      }
     },
     response: {
       body: JSON.stringify([

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -278,6 +278,23 @@ exports.execInContainer = function (parameters, callback) {
   });
 };
 
+// List all files that were modified, added or deleted in a Docker container.
+exports.listChangedFilesInContainer = function (parameters, callback) {
+  const { host, container: containerId } = parameters;
+
+  getDocker(host, (error, docker) => {
+    if (error) {
+      callback(error);
+      return;
+    }
+
+    const container = docker.getContainer(containerId);
+    container.changes((error, changedFiles) => {
+      callback(error, changedFiles);
+    });
+  });
+};
+
 // Kill and delete a Docker container from a given host.
 exports.removeContainer = function (parameters, callback) {
   const { host, container: containerId } = parameters;

--- a/static/css/janitor.css
+++ b/static/css/janitor.css
@@ -284,6 +284,7 @@ h4 {
 .top-right-controls > * {
   float: right;
   margin: -5px 0 0 10px;
+  position: relative;
   z-index: 10;
 }
 

--- a/static/css/janitor.css
+++ b/static/css/janitor.css
@@ -532,6 +532,18 @@ h4 {
   line-height: 1.19; /* The Docker containers ASCII tree shows gaps > 1.20 */
 }
 
+.diff-added {
+  color: #28a745;
+}
+
+.diff-deleted {
+  color: #cb2431;
+}
+
+.diff-hidden {
+  color: #a3aab1;
+}
+
 /* Sections */
 
 section.alert {

--- a/templates/admin-docker.html
+++ b/templates/admin-docker.html
@@ -24,7 +24,7 @@
                 <button class="btn btn-default btn-xs" data-hostname="{{= hostname in xmlattr}}">Refresh</button>
               </div>
               <div class="col-sm-12">
-                <label>Container tree (slow)</label>
+                <label>Container tree</label>
                 <pre></pre>
               </div>
             </div>

--- a/templates/admin-docker.html
+++ b/templates/admin-docker.html
@@ -28,6 +28,20 @@
                 <pre></pre>
               </div>
             </div>
+            <div class="docker-diff row">
+              <div class="col-sm-12">
+                <label>Changed files</label>
+                <form class="ajax-form has-feedback" data-hostname="{{= hostname in xmlattr}}">
+                  <div class="input-group input-group-sm">
+                    <input class="form-control" name="container" placeholder="Container ID" style="margin: 0" type="text">
+                    <span class="input-group-btn">
+                      <button class="btn btn-default btn-sm" type="submit">Refresh</button>
+                    </span>
+                  </div>
+                </form>
+                <pre></pre>
+              </div>
+            </div>
           </div>
         </div>
         <div>{{

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -58,11 +58,6 @@ tests.push({
     // Fake several Docker methods for testing.
     // TODO Maybe use a real Docker Remote API server (or a full mock) for more
     // realistic tests?
-    docker.runContainer = function (parameters, callback) {
-      callback(null, { id: 'abcdef0123456789' }, '');
-    };
-    docker.copyIntoContainer = docker.execInContainer =
-      function (parameters, callback) { callback(); };
     docker.pullImage = function (parameters, callback) {
       const readable = new stream.Readable();
       readable.push('ok');
@@ -73,6 +68,17 @@ tests.push({
       callback(null, { Created: 1500000000000 });
     };
     docker.tagImage = function (parameters, callback) { callback(); };
+    docker.runContainer = function (parameters, callback) {
+      callback(null, { id: 'abcdef0123456789' }, '');
+    };
+    docker.copyIntoContainer = docker.execInContainer =
+      function (parameters, callback) { callback(); };
+    docker.listChangedFilesInContainer = function (parameters, callback) {
+      callback(null, [
+        { Path: '/tmp', Kind: 0 },
+        { Path: '/tmp/test', Kind: 1 }
+      ]);
+    };
     docker.version = function (parameters, callback) {
       callback(null, { Version: '17.06.0-ce' });
     };


### PR DESCRIPTION
The new documentation entry looks like this:

![docker-diff](https://user-images.githubusercontent.com/599268/30396771-00d806ba-98cb-11e7-8928-cef734d054ac.png)

Here is what the feature looks like when you inspect filesystem changes in a given container from the Docker administration interface:

![docker-diff-files](https://user-images.githubusercontent.com/599268/30438222-fb68cba0-9970-11e7-8fae-0df5b540efc4.png)

EDIT: All paths are now sorted alphabetically.