### PR TITLE
Rename Contributions to Containers

### DIFF
--- a/app.js
+++ b/app.js
@@ -228,8 +228,13 @@ boot.executeInParallel([
     });
   });
 
-  // User contributions list.
+  // User contributions list. (legacy - redirect to containers page)
   app.route(/^\/contributions\/?$/, (data, match, end, query) => {
+    routes.redirect(query.res, '/containers/', true);
+  });
+
+  // User containers list.
+  app.route(/^\/containers\/?$/, (data, match, end, query) => {
     const { req: request, res: response } = query;
     const { user } = request;
     if (!user) {
@@ -237,7 +242,7 @@ boot.executeInParallel([
       return;
     }
 
-    routes.contributionsPage(response, user);
+    routes.containersPage(response, user);
   });
 
   // User notifications.

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -189,10 +189,10 @@ exports.loginPage = function (response) {
   ]);
 };
 
-// User contributions list.
-const contributionsTemplate = camp.template('./templates/contributions.html');
-exports.contributionsPage = function (response, user = null) {
-  const title = 'My Contributions';
+// User containers list.
+const containersTemplate = camp.template('./templates/containers.html');
+exports.containersPage = function (response, user = null) {
+  const title = 'My Containers';
   const projects = db.get('projects');
 
   response.template({
@@ -205,7 +205,7 @@ exports.contributionsPage = function (response, user = null) {
     ]
   }, [
     appHeader,
-    contributionsTemplate,
+    containersTemplate,
     appFooter,
   ]);
 };

--- a/static/css/janitor.css
+++ b/static/css/janitor.css
@@ -436,14 +436,14 @@ h4 {
 }
 
 @media (max-width: 768px) {
-  .contributions .panel-heading {
+  .containers .panel-heading {
     justify-content: space-between;
     flex-wrap: wrap;
   }
-  .contributions .project-icon {
+  .containers .project-icon {
     margin-right: 5px;
   }
-  .contributions .project-title {
+  .containers .project-title {
     order: 5;
     margin: 10px 0 0;
     width: 100%;
@@ -552,7 +552,7 @@ section.alert {
   margin: 0;
 }
 
-section.contributions > .container,
+section.containers > .container,
 section.data > .container,
 section.login > .container,
 section.projects > .container,

--- a/static/js/projects.js
+++ b/static/js/projects.js
@@ -10,7 +10,7 @@ Array.map(document.querySelectorAll('a[data-action="spawn"]'), function (link) {
       project: link.dataset.project
     };
     query.resp = function (data) {
-      document.location = '/contributions/';
+      document.location = '/containers/';
     };
   }));
 });

--- a/templates/containers.html
+++ b/templates/containers.html
@@ -1,6 +1,6 @@
-    <section class="contributions">
+    <section class="containers">
       <div class="container">
-        <h2 class="header">My Contributions</h2>{{
+        <h2 class="header">My Containers</h2>{{
           for (let projectId in user.machines) {
             const machines = user.machines[projectId];
             const project = projects[projectId];

--- a/templates/header.html
+++ b/templates/header.html
@@ -26,7 +26,7 @@
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav navbar-right">{{if user then {{
             <li><a href="/projects/">Projects</a></li>
-            <li><a href="/contributions/">Contributions</a></li>
+            <li><a href="/containers/">Containers</a></li>
             <li><a href="/settings/">Settings</a></li>
             <li><a href="/logout">Sign out</a></li>}} else {{
             <li><a href="/login">Sign in</a></li>}}}}

--- a/templates/projects-hint.html
+++ b/templates/projects-hint.html
@@ -3,7 +3,7 @@
         <div class="row">
           <small>
             <span class="glyphicon glyphicon-education" aria-hidden="true"></span>
-            <strong>ProTip!</strong> Later, all the projects that you opened will be in <a href="/contributions/">Contributions</a>.
+            <strong>ProTip!</strong> Later, all the projects that you opened will be in <a href="/containers/">Containers</a>.
           </small>
         </div>
       </div>


### PR DESCRIPTION
This PR addresses part of #59, renaming Contributions to Containers and also redirecting from contributions to containers. 

Upon scanning the repository with Cloud 9, I found that `/dockerfiles/ubuntu-dev/client-workspace-janitor.js` has a [reference](https://github.com/JanitorTechnology/dockerfiles/blob/master/ubuntu-dev/workspace-janitor.js#L27) to contributions but I was unsuccessful in adding it to the PR. Would it be better to commit this to the [dockerfiles repository](https://github.com/JanitorTechnology/dockerfiles/)?