### PR TITLE
Add helpful anchor links to title elements with an 'id' attribute.

### DIFF
--- a/static/css/janitor.css
+++ b/static/css/janitor.css
@@ -475,6 +475,10 @@ h4 {
   margin-right: -2px;
 }
 
+*:not(:hover) > .show-on-hover {
+  visibility: hidden;
+}
+
 /* API reference */
 
 .reference h1:not(:first-of-type) {

--- a/static/js/janitor.js
+++ b/static/js/janitor.js
@@ -272,15 +272,22 @@ $('.modal-form').on('hidden.bs.modal', function (event) {
 });
 
 // Remove the query string (e.g. '?key=123') from the URL.
-function removeQueryString () {
-  var search = window.location.search;
-  if (search) {
-    var url = String(window.location).replace(search, '');
-    window.history.replaceState({}, document.title, url);
-  }
+if (window.location.search) {
+  var url = String(window.location).replace(window.location.search, '');
+  window.history.replaceState({}, document.title, url);
 }
 
-removeQueryString();
+// Add helpful anchor links to title elements with an 'id' attribute.
+Array.forEach(document.querySelectorAll('h1[id],h2[id]'), element => {
+  const link = document.createElement('a');
+  link.href = '#' + element.id;
+  link.textContent = '#';
+  const small = document.createElement('small');
+  small.classList.add('show-on-hover');
+  small.appendChild(link);
+  element.appendChild(document.createTextNode(' '));
+  element.appendChild(small);
+});
 
 // If the web browser supports it, register and install a Service Worker.
 if ('serviceWorker' in navigator) {


### PR DESCRIPTION
Title elements in the "Blog" and "API" pages already have unique `id` attributes.

This pull request adds small "#" links to facilitate referencing specific titles inside a page.