### PR TITLE
Do not strip the path prefix from Discourse

### DIFF
--- a/lib/proxy-heuristics.js
+++ b/lib/proxy-heuristics.js
@@ -37,7 +37,10 @@ exports.handleProxyUrls = function (request, response, next) {
     }
 
     // Locally remove the prefix from `request.url`.
-    request.url = request.url.replace('/' + containerId + '/' + port, '');
+    // port 3000 is used by Discourse, which expects the paths to be passed on unmodified
+    if (port != 3000) {
+      request.url = request.url.replace('/' + containerId + '/' + port, '');
+    }
   } else if (request.headers.referer) {
     // Look for a container ID and port in `request.headers.referer`.
     const referer = nodeurl.parse(request.headers.referer);


### PR DESCRIPTION
Discourse supports path prefixes, as long as you leave them in when forwarding the request on.