### PR TITLE
Fix allowing admin users to sign in without invitation.

### DIFF
--- a/lib/users.js
+++ b/lib/users.js
@@ -145,7 +145,7 @@ exports.sendLoginEmail = function (email, request, callback) {
     }
 
     // Alpha version is invite-only.
-    if (!(email in db.get('users')) && !exports.isAdmin({ emails: [email] })) {
+    if (!(email in db.get('users')) && !exports.isAdmin({ _primaryEmail: email })) {
       // Add unknown emails to the waitlist.
       const waitlist = db.get('waitlist');
       if (!(email in waitlist)) {


### PR DESCRIPTION
This is a small regression from a previous refactor of user emails (it only slightly affects Janitor users during development, but it's still nice to fix it).

@nt1m could you please have a look? 😄 