### PR TITLE
Add support for proxying HTTPS without URL rewrite

### DIFF
--- a/join.js
+++ b/join.js
@@ -236,21 +236,19 @@ function proxyRequest (request, response) {
 
 // Route a request to the given port, using the given proxy type.
 function routeRequest (proxyParameters, request, response) {
-  const path = nodepath.normalize(request.url);
-  if (path[0] !== '/') {
-    log('[fail] invalid proxy path:', path);
-    response.statusCode = 500; // Internal Server Error
-    response.end();
-    return;
-  }
-
   const { port, proxy } = proxyParameters;
   switch (proxy) {
     case 'https':
+      const path = nodepath.normalize(request.url);
+      routes.webProxy(request, response, { port, path });
+    
+    case 'https-auto':
+      const path = nodepath.normalize(request.query.url);
       routes.webProxy(request, response, { port, path });
       break;
 
     case 'none':
+      const path = nodepath.normalize(request.query.url);
       routes.redirect(response, 'https://' + hostname + ':' + port + path);
       break;
 

--- a/lib/proxy-heuristics.js
+++ b/lib/proxy-heuristics.js
@@ -37,13 +37,16 @@ exports.handleProxyUrls = function (request, response, next) {
     }
 
     // Locally remove the prefix from `request.url`.
-    request.url = request.url.replace('/' + containerId + '/' + port, '');
+    request.query.url = request.url.replace('/' + containerId + '/' + port, '');
   } else if (request.headers.referer) {
     // Look for a container ID and port in `request.headers.referer`.
     const referer = nodeurl.parse(request.headers.referer);
     match = exports.proxyUrlPrefix.exec(referer.pathname);
     if (match) {
       [url, containerId, port, path] = match;
+      // Since there is no prefix,
+      // treat the full requested URL as the "stripped" version.
+      request.query.url = request.url;
     }
   }
 


### PR DESCRIPTION
The current behavior is put under the `https-auto` proxy type, and the new behavior is `https` itself.