### PR TITLE
Implement a Discourse-backed blog page

### DIFF
--- a/api/blog-api.js
+++ b/api/blog-api.js
@@ -4,6 +4,7 @@
 const selfapi = require('selfapi');
 
 const blog = require('../lib/blog');
+const log = require('../lib/log');
 
 // API resource to manage Janitor's Discourse-backed news section.
 const blogAPI = module.exports = selfapi({
@@ -18,7 +19,7 @@ webhookAPI.get({
   description: 'Pull the blog section from Discourse.',
 
   handler: (_request, response) => {
-    blog.pull();
+    blog.pull().then(null, log);
     response.json({}, null, 2);
   },
 

--- a/api/blog-api.js
+++ b/api/blog-api.js
@@ -11,21 +11,27 @@ const blogAPI = module.exports = selfapi({
   title: 'Blog'
 });
 
-// API sub-resource for the sync webhook.
-const webhookAPI = blogAPI.api('/sync-webhook');
-
-webhookAPI.get({
-  title: 'Synchronize',
+// API sub-resource for the Discourse-Blog synchronization webhook.
+// should show up as https://janitor.technology/api/blog/synchronize
+blogAPI.get('/synchronize', {
+  title: 'Synchronize Blog',
   description: 'Pull the blog section from Discourse.',
 
-  handler: (_request, response) => {
-    blog.pull().then(null, log);
-    response.json({}, null, 2);
+  handler: async (_request, response) => {
+    try {
+      const status = await blog.synchronize();
+      log('synchronized blog', status);
+      response.json(status, null, 2);
+    } catch (error) {
+      log('[fail] synchronized blog', error);
+      response.statusCode = 500; // Internal Server Error
+      response.json({ error: 'Could not synchronize' }, null, 2);
+    }
   },
 
   examples: [{
     response: {
-      body: JSON.stringify({}, null, 2)
+      body: JSON.stringify({count: 1}, null, 2)
     }
   }]
 });

--- a/api/blog-api.js
+++ b/api/blog-api.js
@@ -1,0 +1,30 @@
+// Copyright © 2017 Michael Howell. All rights reserved.
+// The following code is covered by the AGPL-3.0 license.
+
+const selfapi = require('selfapi');
+
+const blog = require('../lib/blog');
+
+// API resource to manage Janitor's Discourse-backed news section.
+const blogAPI = module.exports = selfapi({
+  title: 'Blog'
+});
+
+// API sub-resource for the sync webhook.
+const webhookAPI = blogAPI.api('/sync-webhook');
+
+webhookAPI.get({
+  title: 'Synchronize',
+  description: 'Pull the blog section from Discourse.',
+
+  handler: (_request, response) => {
+    blog.pull();
+    response.json({}, null, 2);
+  },
+
+  examples: [{
+    response: {
+      body: JSON.stringify({}, null, 2)
+    }
+  }]
+});

--- a/api/blog-api.js
+++ b/api/blog-api.js
@@ -11,17 +11,15 @@ const blogAPI = module.exports = selfapi({
   title: 'Blog'
 });
 
-// API sub-resource for the Discourse-Blog synchronization webhook.
-// should show up as https://janitor.technology/api/blog/synchronize
 blogAPI.get('/synchronize', {
   title: 'Synchronize Blog',
   description: 'Pull the blog section from Discourse.',
 
   handler: async (_request, response) => {
     try {
-      const status = await blog.synchronize();
-      log('synchronized blog', status);
-      response.json(status, null, 2);
+      const { count } = await blog.synchronize();
+      log('synchronized blog', { count });
+      response.json({ count }, null, 2);
     } catch (error) {
       log('[fail] synchronized blog', error);
       response.statusCode = 500; // Internal Server Error
@@ -31,7 +29,7 @@ blogAPI.get('/synchronize', {
 
   examples: [{
     response: {
-      body: JSON.stringify({count: 1}, null, 2)
+      body: JSON.stringify({ count: 1 }, null, 2)
     }
   }]
 });

--- a/api/index.js
+++ b/api/index.js
@@ -11,6 +11,7 @@ const api = module.exports = selfapi({
 });
 
 // Janitor API sub-resources.
+api.api('/blog', require('./blog-api'));
 api.api('/hosts', require('./hosts-api'));
 api.api('/projects', require('./projects-api'));
 api.api('/user', require('./user-api'));

--- a/app.js
+++ b/app.js
@@ -119,12 +119,6 @@ boot.executeInParallel([
     routes.blogPageNew(query.res, {user, blog: blog.getDb()});
   });
 
-  // New public blog page webhook.
-  app.route(/^\/blog-new-webhook\/?$/, (data, match, end, query) => {
-    log('blog-new-webhook');
-    routes.blogWebhookNew(query.res);
-  });
-
   // Public live data page.
   app.route(/^\/data\/?$/, (data, match, end, query) => {
     const { user } = query.req;

--- a/app.js
+++ b/app.js
@@ -117,7 +117,7 @@ boot.executeInParallel([
     const { req: request, res: response } = query;
     const { user } = request;
     log('blog-new');
-    routes.blogPageNew(response, {blog, user, topics: blog.getDb().topics});
+    routes.blogPageNew(response, user, blog);
   });
 
   // Public live data page.

--- a/app.js
+++ b/app.js
@@ -114,9 +114,10 @@ boot.executeInParallel([
 
   // New public blog page.
   app.route(/^\/blog-new\/?$/, (data, match, end, query) => {
-    const { user } = query.req;
+    const { req: request, res: response } = query;
+    const { user } = request;
     log('blog-new');
-    routes.blogPageNew(query.res, {user, blog: blog.getDb()});
+    routes.blogPageNew(response, {blog, user, topics: blog.getDb().topics});
   });
 
   // Public live data page.

--- a/app.js
+++ b/app.js
@@ -6,6 +6,7 @@ const nodepath = require('path');
 const selfapi = require('selfapi');
 
 const api = require('./api/');
+const blog = require('./lib/blog');
 const boot = require('./lib/boot');
 const db = require('./lib/db');
 const github = require('./lib/github');
@@ -109,6 +110,19 @@ boot.executeInParallel([
     const { user } = query.req;
     log('blog');
     routes.blogPage(query.res, user);
+  });
+
+  // New public blog page.
+  app.route(/^\/blog-new\/?$/, (data, match, end, query) => {
+    const { user } = query.req;
+    log('blog-new');
+    routes.blogPageNew(query.res, {user, blog: blog.getDb()});
+  });
+
+  // New public blog page webhook.
+  app.route(/^\/blog-new-webhook\/?$/, (data, match, end, query) => {
+    log('blog-new-webhook');
+    routes.blogWebhookNew(query.res);
   });
 
   // Public live data page.

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -1,0 +1,85 @@
+// Copyright © 2015 Jan Keromnes. All rights reserved.
+// The following code is covered by the AGPL-3.0 license.
+
+const db = require('./db');
+const https = require('https');
+const metrics = require('./metrics');
+
+const fetchDiscourseAPI = function (url) {
+  return new Promise((resolve, reject) => {
+    const doResolve = (succ) => {
+      let results = '';
+      succ.on('data', (chunk) => {
+        try {
+          results += chunk;
+        } catch (e) {
+          succ.destroy(e);
+        }
+      });
+      succ.on('error', reject);
+      succ.on('end', () => {
+        try {
+          resolve(JSON.parse(results));
+        } catch (e) {
+          reject(e);
+        }
+      });
+    };
+    https.get(url + '.json', doResolve);
+  });
+};
+
+const getDb = function () {
+  return db.get('blog', {
+    'posts': [],
+    'topics_url': 'https://discourse.janitor.technology/tags/published',
+    'post_url_template': 'https://discourse.janitor.technology/t/{{slug}}/{{id}}/1',
+    'comments_url_template': 'https://discourse.janitor.technology/t/{{slug}}/{{id}}/2',
+    'filter_category_id': 9,
+    'data': {
+      'updated': null,
+      'pull-time': [
+      ],
+    },
+  });
+};
+
+const pull = async function () {
+  const blog = getDb();
+  const topic = await fetchDiscourseAPI(blog.topics_url);
+  blog.posts = topic.topic_list.topics;
+  const time = Date.now();
+  for (const post_i in blog.posts) {
+    if (blog.posts[post_i].category_id !== blog.filter_category_id) {
+      delete blog.posts[post_i];
+    }
+  }
+  blog.posts.sort(function (a, b) {
+    let ret_val;
+    if (a.created_at > b.created_at) {
+      ret_val = -1;
+    } else if (a.created_at === b.created_at) {
+      ret_val = 0;
+    } else {
+      ret_val = 1;
+    }
+    return ret_val;
+  });
+  for (const post_i in blog.posts) {
+    const post_meta = blog.posts[post_i];
+    const post_body_url = blog.post_url_template
+      .replace('{{slug}}', post_meta.slug)
+      .replace('{{id}}', post_meta.id);
+    const post_body = (await fetchDiscourseAPI(post_body_url)).post_stream.posts[0].cooked;
+    blog.posts[post_i].body_html = post_body;
+  }
+  const now = Date.now();
+  metrics.set(blog, 'updated', now);
+  metrics.push(blog, 'pull-time', [now, Date.now() - time]);
+  db.save();
+};
+
+module.exports = {
+  'pull': pull,
+  'getDb': getDb,
+};

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -68,7 +68,7 @@ exports.getCommentsUrl = function (topic) {
 exports.synchronize = async function () {
   const blog = module.exports.getDb();
   const time = Date.now();
-  let topics = await fetchDiscourseAPI(discourseBlogTopicsUrl).topic_list.topics;
+  let topics = (await fetchDiscourseAPI(discourseBlogTopicsUrl)).topic_list.topics;
   // Remove "published" topics that are not actual blog posts.
   for (const i in topics) {
     if (topics[i].category_id !== discourseBlogCategoryID) {
@@ -88,7 +88,7 @@ exports.synchronize = async function () {
   });
   blog.topics = await Promise.all(topics.map(async topic => {
     const bodyUrl = module.exports.getPostUrl(topic);
-    const bodyHtml = await fetchDiscourseAPI(bodyUrl).post_stream.posts[0].cooked;
+    const bodyHtml = (await fetchDiscourseAPI(bodyUrl)).post_stream.posts[0].cooked;
     topic.post_body_html = bodyHtml;
     return topic;
   }));

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -21,17 +21,17 @@ const discourseBlogCommentsUrlTemplate = 'https://discourse.janitor.technology/t
 // Perform an asynchronous Discourse API request.
 function fetchDiscourseAPI (url) {
   return new Promise((resolve, reject) => {
-    https.get(url + '.json', response_stream => {
+    https.get(url + '.json', responseStream => {
       let json = '';
-      response_stream.on('data', (chunk) => {
+      responseStream.on('data', (chunk) => {
         try {
-          json += chunk;
+          json += String(chunk);
         } catch (error) {
-          response_stream.destroy(error);
+          responseStream.destroy(error);
         }
       });
-      response_stream.on('error', reject);
-      response_stream.on('end', () => {
+      responseStream.on('error', reject);
+      responseStream.on('end', () => {
         try {
           resolve(JSON.parse(json));
         } catch (error) {
@@ -46,10 +46,6 @@ function fetchDiscourseAPI (url) {
 exports.getDb = function () {
   return db.get('blog', {
     'topics': [],
-    'data': {
-      'updated': null,
-      'pull-time': [],
-    },
   });
 };
 
@@ -96,7 +92,7 @@ exports.synchronize = async function () {
   blog.topics = await Promise.all(topicsPromises);
   const now = Date.now();
   metrics.set(blog, 'updated', now);
-  metrics.push(blog, 'pull-time', [now, Date.now() - time]);
+  metrics.push(blog, 'pull-time', [now, now - time]);
   db.save();
   return { count: topics.length };
 };

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -1,4 +1,4 @@
-// Copyright © 2015 Jan Keromnes. All rights reserved.
+// Copyright © 2017 Michael Howell. All rights reserved.
 // The following code is covered by the AGPL-3.0 license.
 
 const db = require('./db');

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -7,8 +7,11 @@ const metrics = require('./metrics');
 
 // Big note for anybody who's trying to understand how the blog works:
 // Discourse is made up of "topics" that contain one or more "posts".
-// The first post in a published (published is a tag) blog (blog is a topic)
-// post is considered the blog post itself. The rest are comments on it.
+// The first post in a published[^1] blog[^2] topic is considered the blog post itself.
+// The rest are comments on it.
+//
+// [^1] "published" is a staff-only-tag.
+// [^2] "blog" is a category, and is not staff-only.
 
 const discourseBlogCategoryID = 9;
 const discourseBlogTopicsUrl = 'https://discourse.janitor.technology/tags/published';
@@ -68,30 +71,29 @@ exports.getCommentsUrl = function (topic) {
 exports.synchronize = async function () {
   const blog = module.exports.getDb();
   const time = Date.now();
-  let { topics } = (await fetchDiscourseAPI(discourseBlogTopicsUrl)).topic_list;
+  const publishedTag = await fetchDiscourseAPI(discourseBlogTopicsUrl);
+  let { topics } = publishedTag.topic_list;
   // Remove "published" topics that are not actual blog posts.
-  for (const i in topics) {
-    if (topics[i].category_id !== discourseBlogCategoryID) {
-      delete topics[i];
-    }
-  }
-  topics = topics.filter(Boolean);
+  topics = topics.filter(topic => {
+    return topic && topic.category_id === discourseBlogCategoryID;
+  });
   // Order topics
   topics.sort((a, b) => {
     if (a.created_at > b.created_at) {
       return -1;
-    } else if (a.created_at === b.created_at) {
-      return 0;
-    } else {
-      return 1;
     }
+    if (a.created_at === b.created_at) {
+      return 0;
+    }
+    return 1;
   });
-  blog.topics = await Promise.all(topics.map(async topic => {
+  const topicsPromises = topics.map(async topic => {
     const bodyUrl = module.exports.getPostUrl(topic);
-    const bodyHtml = (await fetchDiscourseAPI(bodyUrl)).post_stream.posts[0].cooked;
-    topic.post_body_html = bodyHtml;
+    const { post_stream } = await fetchDiscourseAPI(bodyUrl);
+    topic.post_body_html = post_stream.posts[0].cooked;
     return topic;
-  }));
+  });
+  blog.topics = await Promise.all(topicsPromises);
   const now = Date.now();
   metrics.set(blog, 'updated', now);
   metrics.push(blog, 'pull-time', [now, Date.now() - time]);

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -68,7 +68,7 @@ exports.getCommentsUrl = function (topic) {
 exports.synchronize = async function () {
   const blog = module.exports.getDb();
   const time = Date.now();
-  let topics = (await fetchDiscourseAPI(discourseBlogTopicsUrl)).topic_list.topics;
+  let { topics } = (await fetchDiscourseAPI(discourseBlogTopicsUrl)).topic_list;
   // Remove "published" topics that are not actual blog posts.
   for (const i in topics) {
     if (topics[i].category_id !== discourseBlogCategoryID) {

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -40,7 +40,7 @@ function fetchDiscourseAPI (url) {
 }
 
 // Get the cached Discourse-backed blog.
-module.exports.getDb = function () {
+exports.getDb = function () {
   return db.get('blog', {
     'topics': [],
     'data': {
@@ -51,24 +51,24 @@ module.exports.getDb = function () {
 };
 
 // Given a post from the database, get the title URL.
-module.exports.getPostUrl = function (topic) {
+exports.getPostUrl = function (topic) {
   return discourseBlogPostUrlTemplate
     .replace('{{slug}}', topic.slug)
     .replace('{{id}}', topic.id);
 };
 
 // Given a post from the database, get the comment URL.
-module.exports.getCommentsUrl = function (topic) {
+exports.getCommentsUrl = function (topic) {
   return discourseBlogCommentsUrlTemplate
     .replace('{{slug}}', topic.slug)
     .replace('{{id}}', topic.id);
 };
 
 // Synchronize the Discourse-backed blog into the database.
-module.exports.synchronize = async function () {
+exports.synchronize = async function () {
   const blog = module.exports.getDb();
   const time = Date.now();
-  let topics = (await fetchDiscourseAPI(discourseBlogTopicsUrl)).topic_list.topics;
+  let topics = await fetchDiscourseAPI(discourseBlogTopicsUrl).topic_list.topics;
   // Remove "published" topics that are not actual blog posts.
   for (const i in topics) {
     if (topics[i].category_id !== discourseBlogCategoryID) {
@@ -88,7 +88,7 @@ module.exports.synchronize = async function () {
   });
   blog.topics = await Promise.all(topics.map(async topic => {
     const bodyUrl = module.exports.getPostUrl(topic);
-    const bodyHtml = (await fetchDiscourseAPI(bodyUrl)).post_stream.posts[0].cooked;
+    const bodyHtml = await fetchDiscourseAPI(bodyUrl).post_stream.posts[0].cooked;
     topic.post_body_html = bodyHtml;
     return topic;
   }));

--- a/lib/blog.js
+++ b/lib/blog.js
@@ -5,81 +5,96 @@ const db = require('./db');
 const https = require('https');
 const metrics = require('./metrics');
 
-const fetchDiscourseAPI = function (url) {
-  return new Promise((resolve, reject) => {
-    const doResolve = (succ) => {
-      let results = '';
-      succ.on('data', (chunk) => {
-        try {
-          results += chunk;
-        } catch (e) {
-          succ.destroy(e);
-        }
-      });
-      succ.on('error', reject);
-      succ.on('end', () => {
-        try {
-          resolve(JSON.parse(results));
-        } catch (e) {
-          reject(e);
-        }
-      });
-    };
-    https.get(url + '.json', doResolve);
-  });
-};
+// Big note for anybody who's trying to understand how the blog works:
+// Discourse is made up of "topics" that contain one or more "posts".
+// The first post in a published (published is a tag) blog (blog is a topic)
+// post is considered the blog post itself. The rest are comments on it.
 
-const getDb = function () {
+const discourseBlogCategoryID = 9;
+const discourseBlogTopicsUrl = 'https://discourse.janitor.technology/tags/published';
+const discourseBlogPostUrlTemplate = 'https://discourse.janitor.technology/t/{{slug}}/{{id}}/1';
+const discourseBlogCommentsUrlTemplate = 'https://discourse.janitor.technology/t/{{slug}}/{{id}}/2';
+
+// Perform an asynchronous Discourse API request.
+function fetchDiscourseAPI (url) {
+  return new Promise((resolve, reject) => {
+    https.get(url + '.json', response_stream => {
+      let json = '';
+      response_stream.on('data', (chunk) => {
+        try {
+          json += chunk;
+        } catch (error) {
+          response_stream.destroy(error);
+        }
+      });
+      response_stream.on('error', reject);
+      response_stream.on('end', () => {
+        try {
+          resolve(JSON.parse(json));
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+  });
+}
+
+// Get the cached Discourse-backed blog.
+module.exports.getDb = function () {
   return db.get('blog', {
-    'posts': [],
-    'topics_url': 'https://discourse.janitor.technology/tags/published',
-    'post_url_template': 'https://discourse.janitor.technology/t/{{slug}}/{{id}}/1',
-    'comments_url_template': 'https://discourse.janitor.technology/t/{{slug}}/{{id}}/2',
-    'filter_category_id': 9,
+    'topics': [],
     'data': {
       'updated': null,
-      'pull-time': [
-      ],
+      'pull-time': [],
     },
   });
 };
 
-const pull = async function () {
-  const blog = getDb();
-  const topic = await fetchDiscourseAPI(blog.topics_url);
-  blog.posts = topic.topic_list.topics;
+// Given a post from the database, get the title URL.
+module.exports.getPostUrl = function (topic) {
+  return discourseBlogPostUrlTemplate
+    .replace('{{slug}}', topic.slug)
+    .replace('{{id}}', topic.id);
+};
+
+// Given a post from the database, get the comment URL.
+module.exports.getCommentsUrl = function (topic) {
+  return discourseBlogCommentsUrlTemplate
+    .replace('{{slug}}', topic.slug)
+    .replace('{{id}}', topic.id);
+};
+
+// Synchronize the Discourse-backed blog into the database.
+module.exports.synchronize = async function () {
+  const blog = module.exports.getDb();
   const time = Date.now();
-  for (const post_i in blog.posts) {
-    if (blog.posts[post_i].category_id !== blog.filter_category_id) {
-      delete blog.posts[post_i];
+  let topics = (await fetchDiscourseAPI(discourseBlogTopicsUrl)).topic_list.topics;
+  // Remove "published" topics that are not actual blog posts.
+  for (const i in topics) {
+    if (topics[i].category_id !== discourseBlogCategoryID) {
+      delete topics[i];
     }
   }
-  blog.posts.sort(function (a, b) {
-    let ret_val;
+  topics = topics.filter(Boolean);
+  // Order topics
+  topics.sort((a, b) => {
     if (a.created_at > b.created_at) {
-      ret_val = -1;
+      return -1;
     } else if (a.created_at === b.created_at) {
-      ret_val = 0;
+      return 0;
     } else {
-      ret_val = 1;
+      return 1;
     }
-    return ret_val;
   });
-  for (const post_i in blog.posts) {
-    const post_meta = blog.posts[post_i];
-    const post_body_url = blog.post_url_template
-      .replace('{{slug}}', post_meta.slug)
-      .replace('{{id}}', post_meta.id);
-    const post_body = (await fetchDiscourseAPI(post_body_url)).post_stream.posts[0].cooked;
-    blog.posts[post_i].body_html = post_body;
-  }
+  blog.topics = await Promise.all(topics.map(async topic => {
+    const bodyUrl = module.exports.getPostUrl(topic);
+    const bodyHtml = (await fetchDiscourseAPI(bodyUrl)).post_stream.posts[0].cooked;
+    topic.post_body_html = bodyHtml;
+    return topic;
+  }));
   const now = Date.now();
   metrics.set(blog, 'updated', now);
   metrics.push(blog, 'pull-time', [now, Date.now() - time]);
   db.save();
-};
-
-module.exports = {
-  'pull': pull,
-  'getDb': getDb,
+  return { count: topics.length };
 };

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -151,15 +151,23 @@ exports.blogPage = function (response, user = null) {
 
 // Public blog page.
 const blogSectionNew = camp.template('./templates/blog-new.html');
-exports.blogPageNew = function (response, params) {
+exports.blogPageNew = function (response, user, blog) {
   const title = 'Blog';
-  const {user, blog, topics} = params;
+  const { topics } = blog.getDb();
+  
+  const contents = topics.map(topic => {
+    const { title, post_body_html, slug, posts_count } = topic;
+    // The newsletter itself counts as a "post" in this "topic".
+    // All other posts are comments.
+    const comments_count = posts_count - 1;
+    const comments_url = comments_count > 0 ? blog.getCommentsUrl(topic) : blog.getPostUrl(topic);
+    return { title, post_body_html, slug, comments_count, comments_url };
+  });
 
   response.template({
+    contents,
     title,
     user,
-    blog,
-    topics,
     scripts: [],
   }, [
     appHeaderNew,

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -9,7 +9,6 @@ const db = require('./db');
 const github = require('./github');
 const log = require('./log');
 const metrics = require('./metrics');
-const blog = require('./blog');
 
 const security = db.get('security');
 
@@ -166,11 +165,6 @@ exports.blogPageNew = function (response, params) {
     blogSectionNew,
     appFooterNew,
   ]);
-};
-
-exports.blogWebhookNew = function (response) {
-  blog.pull();
-  response.json({}, null, 2);
 };
 
 // Public projects list page.

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -155,7 +155,7 @@ exports.blogPageNew = function (response, user, blog) {
   const title = 'Blog';
   const { topics } = blog.getDb();
 
-  const contents = topics.map(topic => {
+  const posts = topics.map(topic => {
     const { title, post_body_html, slug, posts_count } = topic;
     // The newsletter itself counts as a "post" in this "topic".
     // All other posts are comments.
@@ -165,7 +165,7 @@ exports.blogPageNew = function (response, user, blog) {
   });
 
   response.template({
-    contents,
+    posts,
     title,
     user,
     scripts: [],

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -9,6 +9,7 @@ const db = require('./db');
 const github = require('./github');
 const log = require('./log');
 const metrics = require('./metrics');
+const blog = require('./blog');
 
 const security = db.get('security');
 
@@ -147,6 +148,29 @@ exports.blogPage = function (response, user = null) {
     blogSection,
     appFooter,
   ]);
+};
+
+// Public blog page.
+const blogSectionNew = camp.template('./templates/blog-new.html');
+exports.blogPageNew = function (response, params) {
+  const title = 'Blog';
+  const {user, blog} = params;
+
+  response.template({
+    title,
+    user,
+    blog,
+    scripts: [],
+  }, [
+    appHeaderNew,
+    blogSectionNew,
+    appFooterNew,
+  ]);
+};
+
+exports.blogWebhookNew = function (response) {
+  blog.pull();
+  response.json({}, null, 2);
 };
 
 // Public projects list page.

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -153,12 +153,13 @@ exports.blogPage = function (response, user = null) {
 const blogSectionNew = camp.template('./templates/blog-new.html');
 exports.blogPageNew = function (response, params) {
   const title = 'Blog';
-  const {user, blog} = params;
+  const {user, blog, topics} = params;
 
   response.template({
     title,
     user,
     blog,
+    topics,
     scripts: [],
   }, [
     appHeaderNew,

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -154,7 +154,7 @@ const blogSectionNew = camp.template('./templates/blog-new.html');
 exports.blogPageNew = function (response, user, blog) {
   const title = 'Blog';
   const { topics } = blog.getDb();
-  
+
   const contents = topics.map(topic => {
     const { title, post_body_html, slug, posts_count } = topic;
     // The newsletter itself counts as a "post" in this "topic".

--- a/static/css/janitor-new.css
+++ b/static/css/janitor-new.css
@@ -81,6 +81,7 @@ main {
   color: #0c0c0d;
   text-decoration: none;
   font: inherit;
+  display: inline-block;
 }
 
 .btn:not(:first-child) {
@@ -480,4 +481,84 @@ main {
 .danger-zone {
   color: #3e0200;
   background: rgba(255, 0, 57, 0.1);
+}
+
+/* Blogs page */
+.blog {
+  font-size: 16px;
+}
+.blog article {
+  border-top: solid 1px #ededf0;
+  margin: 1.5em 0;
+}
+.blog article:first-child {
+  border: none;
+  padding-top: 0;
+}
+.blog footer {
+  margin: 1.5em 0;
+}
+.onebox {
+  box-shadow: 0 2px 8px rgba(12,12,13,.1);
+  padding: 0.75em;
+  margin: 20px 0;
+  font-size: 14px;
+}
+article.onebox-body {
+  border: none;
+  padding: 0 0;
+  margin-top: 10px;
+  margin-bottom: 0;
+}
+.onebox .source a,
+.onebox .label1,
+.onebox .label2 {
+  color: #38383d;
+}
+.onebox .source img {
+  vertical-align: middle;
+}
+.onebox .label2 {
+  float: right;
+}
+.onebox-body p {
+  margin-bottom: 0;
+}
+.onebox-body .aspect-image {
+  max-height: 170px;
+  --magic-ratio: calc(var(--aspect-ratio) + 0.15);
+  width: calc(128px * var(--magic-ratio));
+  max-width: 20%;
+  float: left;
+  margin-right: 10px;
+  height: auto;
+}
+.onebox-body img {
+  width: 100%;
+}
+.onebox-body h3 {
+  margin-top: 0;
+}
+article a {
+  text-decoration: none;
+}
+
+article a:hover {
+  text-decoration: underline;
+}
+
+article a,
+article a:hover,
+article a:focus {
+  color: #0060df;
+}
+
+article a:active {
+  color: #003eaa;
+}
+
+article a:focus {
+  box-shadow: 0 0 0 1px #0a84ff, 0 0 0 4px rgba(10, 132, 255, 0.2);
+  border-radius: 2px;
+  text-decoration: none;
 }

--- a/static/css/janitor-new.css
+++ b/static/css/janitor-new.css
@@ -483,47 +483,58 @@ main {
   background: rgba(255, 0, 57, 0.1);
 }
 
-/* Blogs page */
+/* Blog page */
+
 .blog {
   font-size: 16px;
 }
+
 .blog article {
   border-top: solid 1px #ededf0;
   margin: 1.5em 0;
 }
+
 .blog article:first-child {
   border: none;
   padding-top: 0;
 }
+
 .blog footer {
   margin: 1.5em 0;
 }
+
 .onebox {
   box-shadow: 0 2px 8px rgba(12,12,13,.1);
   padding: 0.75em;
   margin: 20px 0;
   font-size: 14px;
 }
+
 article.onebox-body {
   border: none;
   padding: 0 0;
   margin-top: 10px;
   margin-bottom: 0;
 }
+
 .onebox .source a,
 .onebox .label1,
 .onebox .label2 {
   color: #38383d;
 }
+
 .onebox .source img {
   vertical-align: middle;
 }
+
 .onebox .label2 {
   float: right;
 }
+
 .onebox-body p {
   margin-bottom: 0;
 }
+
 .onebox-body .aspect-image {
   max-height: 170px;
   --magic-ratio: calc(var(--aspect-ratio) + 0.15);
@@ -533,12 +544,15 @@ article.onebox-body {
   margin-right: 10px;
   height: auto;
 }
+
 .onebox-body img {
   width: 100%;
 }
+
 .onebox-body h3 {
   margin-top: 0;
 }
+
 article a {
   text-decoration: none;
 }

--- a/static/css/janitor-new.css
+++ b/static/css/janitor-new.css
@@ -486,7 +486,10 @@ main {
 /* Blog page */
 
 .blog {
-  font-size: 16px;
+  font-size: 18px;
+  line-height: 1.6;
+  max-width: 700px;
+  margin: 0 auto;
 }
 
 .blog article {
@@ -543,6 +546,11 @@ article.onebox-body {
   float: left;
   margin-right: 10px;
   height: auto;
+}
+
+.onebox .site-icon {
+  width: 16px;
+  height: 16px;
 }
 
 .onebox-body img {

--- a/static/js/janitor-new.js
+++ b/static/js/janitor-new.js
@@ -263,6 +263,10 @@ Array.forEach(document.querySelectorAll('h1[id],h2[id]'), element => {
   element.appendChild(small);
 });
 
+Array.forEach(document.querySelectorAll('.blog article p a'), element => {
+  element.target = '_blank';
+});
+
 // If the web browser supports it, register and install a Service Worker.
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.register('/service-worker.js', { scope: '/' })

--- a/templates/blog-new.html
+++ b/templates/blog-new.html
@@ -1,18 +1,12 @@
     <section class="blog">{{
-        for (const topic of topics) {
-          const {title, post_body_html, slug, id, posts_count} = topic;
-          const title_url = blog.getPostUrl(topic);
-          // the newsletter itself counts as a "post" in this "topic"
-          // all other posts are comments
-          const comments_count = posts_count - 1;
-          const comments_url = blog.getCommentsUrl(topic);
-          const url = comments_count > 0 ? comments_url : title_url;
+        for (const topic of contents) {
+          const { title, post_body_html, slug, comments_count, comments_url } = topic;
       }}
       <article>
-        <h2 id="{{= slug in xmlattr}}">{{= title in html}}</h2>
+        <h1 id="{{= slug in xmlattr}}">{{= title in html}}</h1>
         {{= post_body_html}}
       </article>
-      <footer><a class="btn" href="{{= url in xmlattr}}">{{= comments_count in html}} comments</a></footer>{{
+      <footer><a class="btn" href="{{= comments_url in xmlattr}}">{{= comments_count in html}} comments</a></footer>{{
       }
       }}
     </section>

--- a/templates/blog-new.html
+++ b/templates/blog-new.html
@@ -1,22 +1,18 @@
     <section class="blog">{{
-        for (let post in blog.posts) {
-          const {title, body_html, slug, id, posts_count} = blog.posts[post];
-          const title_url = blog.post_url_template
-            .replace("{{slug}}", slug)
-            .replace("{{id}}", id);
+        for (const topic of topics) {
+          const {title, post_body_html, slug, id, posts_count} = topic;
+          const title_url = blog.getPostUrl(topic);
           // the newsletter itself counts as a "post" in this "topic"
           // all other posts are comments
           const comments_count = posts_count - 1;
-          const comments_url = blog.comments_url_template
-            .replace("{{slug}}", slug)
-            .replace("{{id}}", id);
+          const comments_url = blog.getCommentsUrl(topic);
           const url = comments_count > 0 ? comments_url : title_url;
       }}
       <article>
         <h2 id="{{= slug in xmlattr}}">{{= title in html}}</h2>
-        {{= body_html}}
+        {{= post_body_html}}
       </article>
-      <footer><a class="btn" href="{{= url}}">{{= comments_count in html}} comments</a></footer>{{
+      <footer><a class="btn" href="{{= url in xmlattr}}">{{= comments_count in html}} comments</a></footer>{{
       }
       }}
     </section>

--- a/templates/blog-new.html
+++ b/templates/blog-new.html
@@ -1,0 +1,22 @@
+    <section class="blog">{{
+        for (let post in blog.posts) {
+          const {title, body_html, slug, id, posts_count} = blog.posts[post];
+          const title_url = blog.post_url_template
+            .replace("{{slug}}", slug)
+            .replace("{{id}}", id);
+          // the newsletter itself counts as a "post" in this "topic"
+          // all other posts are comments
+          const comments_count = posts_count - 1;
+          const comments_url = blog.comments_url_template
+            .replace("{{slug}}", slug)
+            .replace("{{id}}", id);
+          const url = comments_count > 0 ? comments_url : title_url;
+      }}
+      <article>
+        <h2 id="{{= slug in xmlattr}}">{{= title in html}}</h2>
+        {{= body_html}}
+      </article>
+      <footer><a class="btn" href="{{= url}}">{{= comments_count in html}} comments</a></footer>{{
+      }
+      }}
+    </section>

--- a/templates/blog-new.html
+++ b/templates/blog-new.html
@@ -1,6 +1,6 @@
     <section class="blog">{{
-        for (const topic of contents) {
-          const { title, post_body_html, slug, comments_count, comments_url } = topic;
+        for (const post of posts) {
+          const { title, post_body_html, slug, comments_count, comments_url } = post;
       }}
       <article>
         <h1 id="{{= slug in xmlattr}}">{{= title in html}}</h1>


### PR DESCRIPTION
How it works
=========

Create the topic in the Newsletter category. If you don't tag it as `#published`, it won't show up. Once you tag it as published (and only staff have permission to tag a topic as published), it will show up on Janitor's blog page.

Also, the webhook payload is not read, and the signature is not validated. So you can manually trigger a poll by pointing your browser at that URL.

Importing old entries
=========

The "slug" in Discourse, which can be seen in the URL, becomes the `#id` of the post on Janitor (for example, the slug of this topic is `newsletters-composed-in-discourse-and-published-in-janitor`). If you don't want to break old links, make sure the post title will result in a correct slug.

Also, you can click the admin wrench and change the topic timestamp. The Janitor's blog page sorts posts by their timestamp, so old newsletter entries will line get sorted correctly.