### PR TITLE
Fix GitHub SSH public keys in ~/.ssh/authorized_keys.

### DIFF
--- a/lib/machines.js
+++ b/lib/machines.js
@@ -344,7 +344,8 @@ exports.deployConfiguration = function (user, machine, file) {
 function deploySSHAuthorizedKeys (user, machine, callback) {
   let authorizedKeys = [ user.keys.cloud9 ];
   if ('github' in user.keys) {
-    authorizedKeys = authorizedKeys.concat(user.keys.github.authorizedKeys);
+    const githubKeys = user.keys.github.authorizedKeys.map(({ key }) => key);
+    authorizedKeys = authorizedKeys.concat(githubKeys);
   }
 
   const { host, container: containerId } = machine.docker;


### PR DESCRIPTION
If you enabled the GitHub integration, you probably have a few `[Object object]` in your containers' `~/.ssh/authorized_keys` files.

This is because SSH public keys imported from GitHub look like `{ id: 1, key: "ssh-rsa AAA..." }` instead of just `"ssh-rsa AAA..."`.