### PR TITLE
Swap body/heading grey background in new design panel.

### DIFF
--- a/static/css/janitor-new.css
+++ b/static/css/janitor-new.css
@@ -337,16 +337,13 @@ main {
   display: flex;
   align-items: center;
   flex-wrap: wrap;
+  background: #fcfcfc;
   border-bottom: 1px solid #ededf0;
 }
 
 .panel-heading > * {
   vertical-align: middle;
   display: inline-block;
-}
-
-.panel-body {
-  background: #fcfcfc;
 }
 
 /* Status icons */


### PR DESCRIPTION
I find it more logical and cleaner to have a grey panel heading and white panel body, as opposed to the current white heading and grey body.

@nt1m please have a look when you have a minute. 😄 