### PR TITLE
Allow scheduling system events persistently.

### DIFF
--- a/api/admin-api.js
+++ b/api/admin-api.js
@@ -91,16 +91,6 @@ azureAPI.get('/virtualmachines', {
 const oauth2providersAPI = adminAPI.api('/oauth2providers', {
   beforeEachTest: next => {
     const providers = db.get('oauth2providers');
-    if (!providers.github) {
-      // FIXME Remove this if block when the GitHub pull request is merged:
-      // https://github.com/JanitorTechnology/janitor/pull/80
-      providers.github = {
-        id: '',
-        secret: '',
-        hostname: 'github.com',
-        api: 'api.github.com'
-      };
-    }
     providers.github.id = '1234';
     providers.github.secret = '123456';
     next();

--- a/api/admin-api.js
+++ b/api/admin-api.js
@@ -6,6 +6,7 @@ const selfapi = require('selfapi');
 
 const azure = require('../lib/azure');
 const db = require('../lib/db');
+const events = require('../lib/events');
 const log = require('../lib/log');
 const users = require('../lib/users');
 
@@ -85,6 +86,55 @@ azureAPI.get('/virtualmachines', {
   },
 
   examples: [],
+});
+
+// API sub-resource to manage scheduled events.
+const eventsAPI = adminAPI.api('/events');
+
+eventsAPI.get({
+  title: 'List past system events',
+
+  handler: (request, response) => {
+    const { user } = request;
+    if (!user || !users.isAdmin(user)) {
+      response.statusCode = 403; // Forbidden
+      response.json({ error: 'Unauthorized' }, null, 2);
+      return;
+    }
+
+    response.json(events.get(), null, 2);
+  },
+
+  examples: [{
+    response: {
+      body: json => {
+        try { return Array.isArray(JSON.parse(json)); } catch (error) { return false; }
+      }
+    }
+  }]
+});
+
+eventsAPI.get('/queue', {
+  title: 'List upcoming system events',
+
+  handler: (request, response) => {
+    const { user } = request;
+    if (!user || !users.isAdmin(user)) {
+      response.statusCode = 403; // Forbidden
+      response.json({ error: 'Unauthorized' }, null, 2);
+      return;
+    }
+
+    response.json(events.getQueue(), null, 2);
+  },
+
+  examples: [{
+    response: {
+      body: json => {
+        try { return Array.isArray(JSON.parse(json)); } catch (error) { return false; }
+      }
+    }
+  }]
 });
 
 // API sub-resource to manage OAuth2 providers.

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const api = require('./api/');
 const blog = require('./lib/blog');
 const boot = require('./lib/boot');
 const db = require('./lib/db');
+const events = require('./lib/events');
 const github = require('./lib/github');
 const hosts = require('./lib/hosts');
 const log = require('./lib/log');
@@ -501,4 +502,7 @@ boot.executeInParallel([
       end({ status: 'started' });
     }, 42000);
   });
+
+  // Start regularly scheduling system events, once start-up is complete.
+  events.startScheduling();
 });

--- a/join.js
+++ b/join.js
@@ -8,6 +8,7 @@ const nodeurl = require('url');
 
 const boot = require('./lib/boot');
 const db = require('./lib/db');
+const events = require('./lib/events');
 const log = require('./lib/log');
 const oauth2 = require('./lib/oauth2');
 const proxyHeuristics = require('./lib/proxy-heuristics');
@@ -79,6 +80,9 @@ boot.executeInParallel([
         });
       });
     });
+
+    // Start regularly scheduling system events, once start-up is complete.
+    events.startScheduling();
   });
 });
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -1,0 +1,150 @@
+// Copyright © 2018 Jan Keromnes.
+// The following code is covered by the AGPL-3.0 license.
+
+const EventEmitter = require('events');
+
+// Note: If you miss an important scheduling feature here, maybe import a "real"
+//   cron-based scheduler module instead of reimplementing one.
+// For example: https://github.com/IMA-WorldHealth/TaskList
+
+const db = require('./db');
+const log = require('./log');
+
+const schedulingInterval = 1000 * 60 * 60 * 10; // Every 10 hours.
+
+const emitter = new EventEmitter();
+const events = db.get('events');
+load();
+
+// Load past and upcoming events from the database.
+function load () {
+  emitter.on('error', error => {
+    log('[fail] event emitter error', error);
+  });
+
+  if (!events.history) {
+    events.history = [];
+  }
+
+  if (!events.queue) {
+    events.queue = [];
+  }
+
+  // Events should flow through the following states:
+  // 1. Queued: `event` is added to `events.queue`
+  // 2. Scheduled: `event.scheduledTime` is set
+  // 3. Emitted: `event.emittedTime` is set, and `event` is moved from
+  //   `events.queue` to `events.history`
+
+  // Remove any empty event slots (already emitted).
+  events.queue = events.queue.filter(event => !!event);
+
+  // Re-schedule any un-emitted events.
+  events.queue.forEach(event => { event.scheduledTime = null; });
+}
+
+// Start regularly scheduling events.
+exports.startScheduling = function () {
+  setTimeout(processQueue, 0);
+};
+
+// Get all previously emitted events.
+exports.get = function () {
+  return events.history;
+};
+
+// Get the queue of upcoming events.
+exports.getQueue = function () {
+  return events.queue
+    .filter(event => !!event) // Remove any empty event slots (already emitted).
+    .sort((a, b) => b.dueTime - a.dueTime); // Sort the queue by due date.
+};
+
+// Register a new event listener.
+exports.on = function (eventType, listener) {
+  emitter.on(eventType, listener);
+};
+
+// Register a single-use event listener.
+exports.once = function (eventType, listener) {
+  emitter.once(eventType, listener);
+};
+
+// Emit an event now.
+exports.emit = function (eventType, payload = null) {
+  exports.emitAtTime(eventType, Date.now(), payload);
+};
+
+// Emit an event at a certain due date (a timestamp).
+exports.emitAtTime = function (eventType, dueTime, payload = null) {
+  const event = createEvent(eventType, dueTime, payload);
+  events.queue.push(event);
+  maybeSchedule(event);
+};
+
+// Process all upcoming events, and schedule any events that are due soon.
+// Note: We schedule events at regular intervals instead of just using
+//   `setTimeout` directly, because `setTimeout` has a maximum range of about
+//   24 days, which is not enough for our needs.
+// See: https://nodejs.org/api/timers.html#timers_settimeout_callback_delay_args
+function processQueue () {
+  log('processing event queue');
+  events.queue.forEach(maybeSchedule);
+  setTimeout(processQueue, schedulingInterval);
+}
+
+// Emit or schedule an event if it's due soon.
+function maybeSchedule (event) {
+  if (!event || event.scheduledTime) {
+    // Already emitted or scheduled, nothing to do.
+    return;
+  }
+
+  const now = Date.now();
+  if (event.dueTime - now >= schedulingInterval) {
+    // The event is not due yet, schedule it later.
+    return;
+  }
+
+  // The event is due soon, schedule it now.
+  event.scheduledTime = now;
+  if (event.dueTime <= now) {
+    // It's due or past due, emit it now.
+    setTimeout(() => { emitEvent(event); }, 0);
+  } else {
+    // It's due soon, emit it before the next queue processing takes place.
+    setTimeout(() => { emitEvent(event); }, event.dueTime - now);
+  }
+}
+
+// Emit an event now.
+function emitEvent (event) {
+  event.consumed = emitter.emit(event.type, event.payload);
+  event.emittedTime = Date.now();
+  if (!event.consumed) {
+    const error = new Error('No listeners for event type: ' + event.type);
+    log('[fail] lost event', event.type, event.payload, error);
+  }
+
+  // Remove the emitted event from the queue.
+  const index = events.queue.indexOf(event);
+  if (index > -1) {
+    // Note: We don't use `.splice()`, to keep indexes stable during iteration.
+    events.queue[index] = null;
+  }
+
+  events.history.push(event);
+  db.save();
+}
+
+// Create a new event to be emitted at a given timestamp.
+function createEvent (type, dueTime, payload = null) {
+  return {
+    type,
+    payload,
+    dueTime,
+    scheduledTime: null,
+    emittedTime: null,
+    consumed: false
+  };
+}


### PR DESCRIPTION
This is basically a re-work of https://github.com/JanitorTechnology/janitor/pull/140/ (sorry for the duplicate work!), which will allow us to schedule potentially long-term system events like "invalidate this token in 24 hours", "delete this container in 1 year", etc.

Here are the differences between this implementation and the "tasks" approach:

- I felt that using an `EventEmitter` was better-suited for registering + triggering callbacks on specific task/event types.
- I also regularly process upcoming tasks/events, but if they're due before the next loop, I use `setTimeout` to trigger them just in time.
- My approach doesn't need a unique task/event IDs.
- It supports multiple listeners for the same event type.
- It doesn't check for errors from the listeners (just if at least one listener was called for this event).