### PR TITLE
Add timeago server-side and use it to pre-render live-updating fuzzy timestamps.

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,6 +3,7 @@
 
 const camp = require('camp');
 const http = require('http');
+const timeago = require('timeago.js');
 
 const configurations = require('./configurations');
 const db = require('./db');
@@ -101,6 +102,7 @@ exports.landingPage = function (response, user = null) {
 
   response.template({
     projects,
+    timeago,
     title,
     user,
     scripts: [
@@ -187,6 +189,7 @@ exports.projectsPage = function (response, user = null) {
 
   response.template({
     projects,
+    timeago,
     title,
     user,
     scripts: [
@@ -207,6 +210,7 @@ exports.projectPage = function (response, project, user = null) {
 
   response.template({
     project,
+    timeago,
     title,
     user,
     scripts: [
@@ -248,6 +252,7 @@ exports.containersPage = function (response, user = null) {
 
   response.template({
     projects,
+    timeago,
     title,
     user,
     scripts: [
@@ -269,6 +274,7 @@ exports.containersPageNew = function (response, user = null) {
 
   response.template({
     projects,
+    timeago,
     title,
     user,
     scripts: [

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "oauth": "0.9.15",
     "oauth2provider": "0.0.2",
     "selfapi": "0.3.0",
-    "tar-stream": "1.5.5"
+    "tar-stream": "1.5.5",
+    "timeago.js": "3.0.2"
   },
   "devDependencies": {
     "eslint": "^4.12.1",

--- a/templates/containers-new.html
+++ b/templates/containers-new.html
@@ -20,7 +20,7 @@
                 <input class="form-control" data-submit-on="blur" name="/name" placeholder="{{= project.name in xmlattr }} #{{= id in id}}" type="text" value="{{= machine.properties.name in xmlattr }}">
               </form>
               <div class="editable-value">
-                <h4 id={{= machine.docker.container in json}}>{{= name in html}}</h4>
+                <h4 id="{{= machine.docker.container.slice(0,16) in xmlattr}}">{{= name in html}}</h4>
                 <span class="icon edit editable-toggle"></span>
               </div>
             </div>
@@ -48,7 +48,11 @@
           </ul>
           <div class="tab-panels">
             <div class="tab-panel padded" data-tab="info">
-              <p class="project-updated">Built <time class="project-timestamp" data-timestamp="{{= machine.data.updated in integer}}"></time>.</p>
+              <p class="project-updated">Built {{
+                const machineUpdatedFuzzy = machine.data.updated
+                  ? timeago().format(machine.data.updated)
+                  : 'never';
+              }}<time class="project-timestamp" data-timestamp="{{= machine.data.updated in integer}}">{{= machineUpdatedFuzzy in html}}</time>.</p>
             </div>
             <div class="tab-panel" data-tab="terminal">
               <iframe src="https://{{= machine.docker.host in uri}}/{{= machine.docker.container.slice(0,16) in uri}}/8087/terminal"></iframe>

--- a/templates/containers.html
+++ b/templates/containers.html
@@ -20,7 +20,7 @@
                 <input class="form-control" data-submit-on="blur" name="/name" placeholder="{{= project.name in xmlattr }} #{{= id in id}}" type="text" value="{{= machine.properties.name in xmlattr }}">
               </form>
               <div class="editable-value">
-                <h4>{{= name in html}}</h4>
+                <h4 id="{{= machine.docker.container.slice(0,16) in xmlattr}}">{{= name in html}}</h4>
                 <span class="glyphicon glyphicon-pencil editable-toggle"></span>
               </div>
             </div>
@@ -48,7 +48,11 @@
             </div>
           </div>
           <div class="panel-body">
-            <p class="project-updated">Built <time class="project-timestamp" data-timestamp="{{= machine.data.updated in integer}}"></time>.</p>
+            <p class="project-updated">Built {{
+              const machineUpdatedFuzzy = machine.data.updated
+                ? timeago().format(machine.data.updated)
+                : 'never';
+            }}<time class="project-timestamp" data-timestamp="{{= machine.data.updated in integer}}">{{= machineUpdatedFuzzy in html}}</time>.</p>
           </div>
         </div>{{
             }

--- a/templates/project.html
+++ b/templates/project.html
@@ -1,10 +1,14 @@
     <section>
       <div class="container">
         <h2 class="header">{{= project.name in html}}</h2>
-        <p>Updated <time class="project-timestamp" data-timestamp="{{= project.data.updated in integer}}"></time>.</p>
+        <p>Built {{
+          const projectUpdatedFuzzy = project.data.updated
+            ? timeago().format(project.data.updated)
+            : 'never';
+        }}<time class="project-timestamp" data-timestamp="{{= project.data.updated in integer}}">{{= projectUpdatedFuzzy in html}}</time>.</p>
         <div class="row">
           <div class="graph col-md-6">
-            <div data-data="{{= project.data['build-time'] in json}}" data-title="Image build"></div>
+            <div data-data="{{= project.data['pull-time'] in json}}" data-title="Image pull"></div>
           </div>
           <div class="graph col-md-6">
             <div data-data="{{= project.data['update-time'] in json}}" data-title="Image update"></div>

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -4,7 +4,7 @@
         <h4>In just a few clicks, enter a fully-functional development environment. Yes, it's that easy.</h4>
         <div class="row">{{
           for (let id in projects) {
-            let project = projects[id];
+            const project = projects[id];
           }}
           <div class="col-sm-12 col-md-6">
             <div class="panel panel-default panel-project">
@@ -20,7 +20,11 @@
               </div>
               <div class="panel-body">
                 <p class="project-description">{{= project.description in html}}</p>
-                <p class="project-updated">Built <time class="project-timestamp" data-timestamp="{{= project.data.updated in integer}}"></time>.</p>
+                <p class="project-updated">Built {{
+                  const projectUpdatedFuzzy = project.data.updated
+                    ? timeago().format(project.data.updated)
+                    : 'never';
+                }}<time class="project-timestamp" data-timestamp="{{= project.data.updated in integer}}">{{= projectUpdatedFuzzy in html}}</time>.</p>
               </div>
             </div>
           </div>{{


### PR DESCRIPTION
Drive-by changes:
- Update container title anchors to 16-char container IDs
- s/Updated/Built/ and s/build-time/pull-time/ in hidden project page