### PR TITLE
Move project descriptions to the project-specific page template. 1/2

### DIFF
--- a/templates/projects.html
+++ b/templates/projects.html
@@ -19,7 +19,6 @@
                 </div>
               </div>
               <div class="panel-body">
-                <p class="project-description">{{= project.description in html}}</p>
                 <p class="project-updated">Built <time class="project-timestamp" data-timestamp="{{= project.data.updated in integer}}"></time>.</p>
               </div>
             </div>


### PR DESCRIPTION
Because otherwise it clutters the projects list on the landing and projects pages.