### PR TITLE
Move project descriptions to the project-specific page template.

### DIFF
--- a/templates/project.html
+++ b/templates/project.html
@@ -1,6 +1,7 @@
     <section>
       <div class="container">
         <h2 class="header">{{= project.name in html}}</h2>
+        <p class="project-description">{{= project.description in html}}</p>
         <p>Built {{
           const projectUpdatedFuzzy = project.data.updated
             ? timeago().format(project.data.updated)

--- a/templates/projects.html
+++ b/templates/projects.html
@@ -19,7 +19,6 @@
                 </div>
               </div>
               <div class="panel-body">
-                <p class="project-description">{{= project.description in html}}</p>
                 <p class="project-updated">Built {{
                   const projectUpdatedFuzzy = project.data.updated
                     ? timeago().format(project.data.updated)


### PR DESCRIPTION
Because otherwise it clutters the projects list on the landing and projects pages. (Was #244.)