### PR TITLE
Remove invalid gitignore entry

### DIFF
--- a/templates/configurations/.gitignore
+++ b/templates/configurations/.gitignore
@@ -95,7 +95,6 @@ capybara-*.html
 .rspec
 .rvmrc
 /.bundle
-**.orig
 rerun.txt
 pickle-email-*.html
 *.gem


### PR DESCRIPTION
** can only be a path component, not a part of filename.