### PR TITLE
Fix WebSocket URL rewriting

### DIFF
--- a/join.js
+++ b/join.js
@@ -73,9 +73,9 @@ boot.executeInParallel([
       request.query = {};
       ensureSession(request, socket, () => {
         ensureOAuth2Access(request, socket, () => {
-          // Note: We don't handle proxy URLs here, because they don't work with
-          // WebSockets (no 'referer' HTTP header in WebSocket requests).
-          proxyRequest(request, socket);
+          proxyHeuristics.handleProxyUrls(request, socket, () => {
+            proxyRequest(request, socket);
+          });
         });
       });
     });

--- a/lib/proxy-heuristics.js
+++ b/lib/proxy-heuristics.js
@@ -1,6 +1,7 @@
 // Copyright © 2017 Jan Keromnes. All rights reserved.
 // The following code is covered by the AGPL-3.0 license.
 
+const http = require('http');
 const nodeurl = require('url');
 
 const log = require('./log');
@@ -31,6 +32,14 @@ exports.handleProxyUrls = function (request, response, next) {
     // However `path` is empty in URLs like '/abc123/8080?p=1', so we redirect
     // them to '/abc123/8080/?p=1' (where `path` is '/').
     if (!path) {
+      // We can only use `http.ServerResponse`s to redirect,
+      // not raw `net.Socket`s (as in WebSocket connections).
+      if (!(response instanceof http.ServerResponse)) {
+        const error = new Error('Unsupported response type (e.g. WebSocket)');
+        log('[fail] trailing slash redirect', error);
+        response.end();
+        return;
+      }
       url = url.includes('?') ? url.replace('?', '/?') : url + '/';
       routes.redirect(response, url, true);
       return;


### PR DESCRIPTION
Theia uses the page URL as the WS endpoint, thus it has to be rewritten. ~Adding to that WebSocket handshakes get a Referer, so our logic just works.~

Some regex related code are modified for clarity (discard variables we don't care, so the variable doesn't have multiple meanings).