### PR TITLE
gitignore: add watchman config

### DIFF
--- a/templates/configurations/.gitignore
+++ b/templates/configurations/.gitignore
@@ -48,6 +48,7 @@
 /.vs/
 /.vscode/
 /_out
+/.watchmanconfig
 GPATH
 GRTAGS
 GSYMS


### PR DESCRIPTION
See: https://facebook.github.io/watchman/docs/config.html

I think we're going to integrate watchman to improve speed of VCS. This is the first step forward.