### PR TITLE
Always use an explicit tag when pulling a Docker image.

### DIFF
--- a/lib/machines.js
+++ b/lib/machines.js
@@ -71,7 +71,7 @@ exports.pull = function (projectId, callback) {
     return;
   }
 
-  const { host, image } = project.docker;
+  const { host, _baseImage: image } = project.docker;
   const time = Date.now();
 
   docker.pullImage({ host, image }, (error, stream) => {
@@ -480,6 +480,15 @@ function getProject (projectId, create) {
   // Temporary migration code: Previous projects didn't have a description.
   if (!project.description) {
     project.description = '';
+  }
+
+  // Get a full Docker image ID, with an explicit tag (by default ':latest').
+  if (!project.docker.hasOwnProperty('_baseImage')) {
+    Object.defineProperty(project.docker, '_baseImage', {
+      get () {
+        return this.image + (this.image.includes(':') ? '' : ':latest');
+      }
+    });
   }
 
   // Get a hidden internal Docker image tagged with ':janitor-production'.


### PR DESCRIPTION
Otherwise, Docker might pull all available image tags:
"Tag or digest. If empty when pulling an image, this causes all tags for the
given image to be pulled."
Source: https://docs.docker.com/engine/api/v1.24/#create-an-image