### PR TITLE
Add --summary by default for qseries and qunapplied

### DIFF
--- a/templates/configurations/.hgrc
+++ b/templates/configurations/.hgrc
@@ -21,6 +21,8 @@ push-to-try = /home/user/.mozbuild/version-control-tools/hgext/push-to-try
 [defaults]
 qnew = -D -U
 qrefresh = -D
+qseries = -s
+qunapplied = -s
 [pager]
 pager = LESS=FRSXQ less
 attend-help = true


### PR DESCRIPTION
It makes it easier to go through the list of patches as it shows the summary as well.