### PR TITLE
UX: Make deleting containers faster and more consistent.

### DIFF
--- a/lib/machines.js
+++ b/lib/machines.js
@@ -9,6 +9,7 @@ const log = require('./log');
 const metrics = require('./metrics');
 const streams = require('./streams');
 
+const containerTrash = db.get('container-trash');
 const maximumContainerLifetime = 1000 * 3600 * 24 * 30 * 6; // About 6 months.
 
 // Get an existing user machine with the given project and machine ID.
@@ -260,30 +261,33 @@ exports.destroy = function (user, projectId, machineId, callback) {
     return;
   }
 
+  // Recycle the machine's name and ports, report success early.
+  machine.status = 'new';
+  machine.docker.container = '';
+  db.save();
+  callback();
+
   const { container: containerId, host } = machine.docker;
   if (!containerId) {
-    // This machine has no associated container, just recycle it as is.
-    machine.status = 'new';
-    db.save();
-    callback();
+    // This machine has no associated container, nothing more to be done.
     return;
   }
 
   log('destroy', containerId.slice(0, 16), 'started');
   docker.removeContainer({ host, container: containerId }, error => {
-    if (error) {
-      log('destroy', containerId.slice(0, 16), error);
-      callback(error);
+    if (!error || error.statusCode === 404) {
+      // Container removed successfully (or already removed)!
+      log('destroy', containerId.slice(0, 16), 'success');
       return;
     }
 
-    // Recycle the machine's name and ports.
-    machine.status = 'new';
-    machine.docker.container = '';
+    // Something went wrong while deleting this container. Try again later.
+    log('destroy', containerId.slice(0, 16), error);
+    if (!containerTrash[host]) {
+      containerTrash[host] = {};
+    }
+    containerTrash[host][containerId] = Date.now();
     db.save();
-
-    log('destroy', containerId.slice(0, 16), 'success');
-    callback();
   });
 };
 


### PR DESCRIPTION
There is no need to make users wait for Docker when removing a container.

We can quickly remove it from the user's account, then wait for Docker to finish
cleaning up in the background. If cleaning up fails, we log the error and save
container ID and host, so that we can try again later.