### PR TITLE
Fix faster container delete logic.

### DIFF
--- a/lib/machines.js
+++ b/lib/machines.js
@@ -261,13 +261,14 @@ exports.destroy = function (user, projectId, machineId, callback) {
     return;
   }
 
+  const { container: containerId, host } = machine.docker;
+  
   // Recycle the machine's name and ports, report success early.
   machine.status = 'new';
   machine.docker.container = '';
   db.save();
   callback();
 
-  const { container: containerId, host } = machine.docker;
   if (!containerId) {
     // This machine has no associated container, nothing more to be done.
     return;

--- a/lib/machines.js
+++ b/lib/machines.js
@@ -262,7 +262,7 @@ exports.destroy = function (user, projectId, machineId, callback) {
   }
 
   const { container: containerId, host } = machine.docker;
-  
+
   // Recycle the machine's name and ports, report success early.
   machine.status = 'new';
   machine.docker.container = '';


### PR DESCRIPTION
Currently, deleting a container works (fast) in the UI, but the backend containers are not actually removed.

This commit fixes the logical bug.