### PR TITLE
Enable debugger support for containers

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -192,7 +192,10 @@ exports.runContainer = function (parameters, callback) {
     const options = {
       Image: image,
       ExposedPorts: {},
-      HostConfig: { PortBindings: {} }
+      HostConfig: {
+        CapAdd: ['SYS_PTRACE'],
+        PortBindings: {},
+      }
     };
 
     for (const port in ports) {


### PR DESCRIPTION
Non-controversial parts split out of #315 (i.e. everything except `seccomp=unconfined`).