### PR TITLE
Remove code about c9.io ssh workspaces

### DIFF
--- a/templates/containers.html
+++ b/templates/containers.html
@@ -25,18 +25,8 @@
             </div>
           </div>
           <div>
-          {{
-            const updated = new Date(machine.data.updated);
-            const c9sdkStart = new Date('2017-08-02');
-            const c9ioEnd = new Date('2017-09-02');
-            if (updated > c9sdkStart && updated < c9ioEnd) { }}
-            <a class="btn" href="https://c9.io/open/ssh?name={{= projectId in id}}-{{= id in id}}&description={{= project.name in uri}}%20on%20janitor.technology&host={{= machine.docker.host in uri}}&port={{= machine.docker.ports['22'].port in integer}}&user=user&workspaceDir={{= project.docker.path in uri}}&nodePath=%2Fhome%2Fuser%2F.c9%2Fnode%2Fbin%2Fnode" target="_blank">c9.io</a>
-          {{ } }}
             <a class="btn" href="https://{{= machine.docker.host in uri}}/{{= machine.docker.container.slice(0,16) in uri}}/8088/vnc.html" target="_blank">VNC</a>
-            <a class="btn btn-primary"{{
-              if (updated < c9sdkStart) { }} href="https://c9.io/open/ssh?name={{= projectId in id}}-{{= id in id}}&description={{= project.name in uri}}%20on%20janitor.technology&host={{= machine.docker.host in uri}}&port={{= machine.docker.ports['22'].port in integer}}&user=user&workspaceDir={{= project.docker.path in uri}}&nodePath=%2Fhome%2Fuser%2F.c9%2Fnode%2Fbin%2Fnode" {{ }
-              else { }} href="https://{{= machine.docker.host in uri}}/{{= machine.docker.container.slice(0,16) in uri}}/8089/ide.html" {{ }
-            }}target="_blank">IDE</a>
+            <a class="btn btn-primary" href="https://{{= machine.docker.host in uri}}/{{= machine.docker.container.slice(0,16) in uri}}/8089/ide.html" target="_blank">IDE</a>
           </div>
         </div>
         <div class="panel-body tabs">


### PR DESCRIPTION
As the former c9.io is now closed, I think we can remove the code about SSH workspace for the IDE.